### PR TITLE
fix: regenerate uv.lock after dependency group consolidation

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -13,33 +13,25 @@ source = { editable = "." }
 
 [package.optional-dependencies]
 dev = [
+    { name = "cairosvg", version = "2.8.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "cairosvg", version = "2.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "mypy" },
+    { name = "pillow", version = "11.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pillow", version = "12.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "pytest", version = "9.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "ruff" },
 ]
 
-[package.dev-dependencies]
-dev = [
-    { name = "cairosvg", version = "2.8.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "cairosvg", version = "2.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "pillow", version = "11.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pillow", version = "12.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-]
-
 [package.metadata]
 requires-dist = [
+    { name = "cairosvg", marker = "extra == 'dev'", specifier = ">=2.8.2" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.14" },
+    { name = "pillow", marker = "extra == 'dev'", specifier = ">=11.3.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.9" },
 ]
 provides-extras = ["dev"]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "cairosvg", specifier = ">=2.8.2" },
-    { name = "pillow", specifier = ">=11.3.0" },
-]
 
 [[package]]
 name = "cairocffi"


### PR DESCRIPTION
## Summary
- Regenerate `uv.lock` after PR #17 moved `cairosvg`/`pillow` from `[dependency-groups]` to `[project.optional-dependencies]`
- Removes stale duplicate entries under `dev-dependencies` in the lockfile

## Test plan
- [x] `uv lock --check` passes
- [x] `uv sync` installs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)