### PR TITLE
feat: action dispatcher with Enter and Cmd modifier support

### DIFF
--- a/src/ha_workflow/actions.py
+++ b/src/ha_workflow/actions.py
@@ -19,16 +19,10 @@ class ActionResult:
 
 
 # Actions whose HA service name differs from our action name.
-_SERVICE_OVERRIDES: dict[str, str] = {
-    "open_cover": "open_cover",
-    "close_cover": "close_cover",
-    "stop_cover": "stop_cover",
-    "return_to_base": "return_to_base",
-    "media_play": "media_play",
-    "media_pause": "media_pause",
-    "media_stop": "media_stop",
-    "set_temperature": "set_temperature",
-}
+# Currently empty — all actions map 1:1. Add overrides here if a
+# user-facing action name ever diverges from the HA service name
+# (e.g. "open" -> "open_cover").
+_SERVICE_OVERRIDES: dict[str, str] = {}
 
 
 def _action_label(action: str) -> str:
@@ -102,6 +96,8 @@ def dispatch_action(
         return ActionResult(success=False, message=f"Connection error: {exc}")
     except HAAuthError as exc:
         return ActionResult(success=False, message=f"Auth error: {exc}")
+    except Exception as exc:
+        return ActionResult(success=False, message=f"Unexpected error: {exc}")
 
     friendly = entity_id.split(".", 1)[1].replace("_", " ").title()
     label = _action_label(action)

--- a/src/ha_workflow/cli.py
+++ b/src/ha_workflow/cli.py
@@ -516,6 +516,19 @@ def _cmd_actions(args: list[str]) -> None:
         return
 
     domain = entity_id.split(".")[0] if "." in entity_id else ""
+    if not domain:
+        output = AlfredOutput(
+            items=[
+                AlfredItem(
+                    title="Invalid entity ID",
+                    subtitle=entity_id,
+                    valid=False,
+                )
+            ]
+        )
+        sys.stdout.write(output.to_json() + "\n")
+        return
+
     dc = get_domain_config(domain)
 
     if not dc.available_actions:

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -148,6 +148,13 @@ class TestDispatchActionErrors:
         assert result.success is False
         assert "Auth error" in result.message
 
+    def test_unexpected_error(self) -> None:
+        client = _mock_client()
+        client.call_service.side_effect = RuntimeError("something broke")
+        result = dispatch_action(client, "light.living_room", "toggle")
+        assert result.success is False
+        assert "Unexpected error" in result.message
+
 
 class TestActionResult:
     def test_dataclass_fields(self) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -908,6 +908,13 @@ class TestActionsCommand:
         data = json.loads(out)
         assert "No entity" in data["items"][0]["title"]
 
+    def test_actions_malformed_entity_id(self, capsys: object) -> None:
+        main(["actions", "badentity"])
+        out = capsys.readouterr().out  # type: ignore[union-attr]
+        data = json.loads(out)
+        assert "Invalid entity ID" in data["items"][0]["title"]
+        assert data["items"][0]["valid"] is False
+
 
 # ---------------------------------------------------------------------------
 # Area lookup


### PR DESCRIPTION
## Summary
- New `actions.py` module with `dispatch_action()` — maps action names to HA service calls, validates against domain registry, returns human-readable `ActionResult` for Alfred notifications
- Wire `_cmd_action()` to dispatch real entity actions (Enter key) and record usage on success
- Implement `_cmd_actions()` sub-menu (Cmd modifier) listing available actions per domain as Alfred Script Filter JSON
- 27 new tests covering dispatcher logic, CLI wiring, error handling, and sub-menu output

Closes #1, Closes #2, Closes #3

## Test plan
- [x] `uv run ruff check src/ tests/` — passes
- [x] `uv run mypy src/` — passes
- [x] `uv run pytest` — 272 passed, 4 skipped
- [ ] Manual: `cli.py action light.living_room toggle` returns success message
- [ ] Manual: `cli.py actions light.living_room` returns Toggle/Turn On/Turn Off menu
- [ ] Manual: `cli.py actions sensor.temperature` returns "No actions available"

🤖 Generated with [Claude Code](https://claude.com/claude-code)