### PR TITLE
feat: parameterized actions with short syntax and interactive entry

### DIFF
--- a/src/ha_workflow/actions.py
+++ b/src/ha_workflow/actions.py
@@ -52,6 +52,9 @@ def _action_label(action: str) -> str:
         "media_pause": "Paused",
         "media_stop": "Stopped",
         "set_temperature": "Temperature set",
+        "set_value": "Value set",
+        "select_option": "Option selected",
+        "volume_set": "Volume set",
     }
     return past.get(action, action.replace("_", " ").title())
 

--- a/src/ha_workflow/cli.py
+++ b/src/ha_workflow/cli.py
@@ -33,7 +33,11 @@ from ha_workflow.alfred import (  # noqa: E402
 )
 from ha_workflow.cache import EntityCache, open_cache  # noqa: E402
 from ha_workflow.config import Config  # noqa: E402
-from ha_workflow.entities import Entity, get_domain_config  # noqa: E402
+from ha_workflow.entities import (  # noqa: E402
+    Entity,
+    get_action_params,
+    get_domain_config,
+)
 from ha_workflow.errors import handle_error  # noqa: E402
 from ha_workflow.ha_client import HAClient  # noqa: E402
 from ha_workflow.notify import (  # noqa: E402
@@ -41,6 +45,7 @@ from ha_workflow.notify import (  # noqa: E402
     notify_background_error,
     notify_error,
 )
+from ha_workflow.params import parse_service_params  # noqa: E402
 from ha_workflow.query_parser import ParsedQuery, parse_query  # noqa: E402
 from ha_workflow.search import fuzzy_search, regex_search  # noqa: E402
 from ha_workflow.suggestions import build_domain_suggestions  # noqa: E402
@@ -540,9 +545,20 @@ def _cmd_action(args: list[str]) -> None:
         _cmd_open_action(entity_id, action)
         return
 
+    # Parse optional inline service params (e.g. "brightness:50,transition:2")
+    raw_params = args[2] if len(args) > 2 else ""
+    domain = entity_id.split(".")[0] if "." in entity_id else ""
+    service_data: Optional[dict[str, object]] = None
+    if raw_params:
+        try:
+            service_data = parse_service_params(raw_params, domain, action)
+        except ValueError as exc:
+            notify_error(str(exc))
+            return
+
     config = Config.from_env()
     client = HAClient(config)
-    result = dispatch_action(client, entity_id, action)
+    result = dispatch_action(client, entity_id, action, service_data=service_data)
     if result.success:
         notify(result.message)
         _cmd_record_usage(entity_id)
@@ -924,10 +940,16 @@ def _cmd_actions(args: list[str]) -> None:
     # --- Domain actions ---
     for action in dc.available_actions:
         label = action.replace("_", " ").title()
+        params = get_action_params(domain, action)
+        if params:
+            param_hints = ", ".join(p.label.lower() for p in params)
+            subtitle = f"{friendly} \u00b7 supports: {param_hints}"
+        else:
+            subtitle = f"{friendly} \u00b7 {domain}"
         items.append(
             AlfredItem(
                 title=label,
-                subtitle=f"{friendly} \u00b7 {domain}",
+                subtitle=subtitle,
                 icon=AlfredIcon(path=dc.icon_path),
                 variables={
                     "entity_id": entity_id,
@@ -1040,15 +1062,134 @@ def _cmd_actions(args: list[str]) -> None:
         )
     )
 
-    # --- Advanced Action Call (stub) ---
-    items.append(
-        AlfredItem(
-            title="Advanced Action Call",
-            subtitle=f"Coming soon \u2014 advanced controls for {domain} entities",
-            icon=AlfredIcon(path=dc.icon_path),
-            valid=False,
+    # --- Advanced Action Call (parameterized) ---
+    if dc.available_actions:
+        # Find all params available for this domain's actions
+        all_params: list[str] = []
+        for act in dc.available_actions:
+            for p in get_action_params(domain, act):
+                if p.name not in all_params:
+                    all_params.append(p.name)
+        if all_params:
+            hint_str = ", ".join(all_params[:4])
+            if len(all_params) > 4:
+                hint_str += ", \u2026"
+            items.append(
+                AlfredItem(
+                    title="Advanced Action Call\u2026",
+                    subtitle=f"e.g. brightness:50%,transition:2 \u00b7 {hint_str}",
+                    icon=AlfredIcon(path=dc.icon_path),
+                    variables={
+                        "entity_id": entity_id,
+                        "action": "action_param",
+                        "domain": domain,
+                    },
+                    valid=False,
+                )
+            )
+
+    output = AlfredOutput(items=items)
+    sys.stdout.write(output.to_json() + "\n")
+
+
+def _cmd_action_param(args: list[str]) -> None:
+    """Interactive parameter entry for Alfred query continuation.
+
+    Usage: ``cli.py action-param <entity_id> <action> [query]``
+
+    When *query* is empty, lists available parameters.  When *query*
+    contains ``key:value`` pairs, validates and shows a confirmation item.
+    """
+    entity_id = args[0] if args else ""
+    action = args[1] if len(args) > 1 else ""
+    query = args[2] if len(args) > 2 else ""
+
+    domain = entity_id.split(".")[0] if "." in entity_id else ""
+    if not entity_id or not action or not domain:
+        output = AlfredOutput(
+            items=[AlfredItem(title="Missing entity or action", valid=False)]
         )
-    )
+        sys.stdout.write(output.to_json() + "\n")
+        return
+
+    params = get_action_params(domain, action)
+    dc = get_domain_config(domain)
+    friendly = entity_id.split(".", 1)[1].replace("_", " ").title()
+
+    items: list[AlfredItem] = []
+
+    if not query:
+        # Show available parameters as hints
+        if not params:
+            items.append(
+                AlfredItem(
+                    title="No parameters available",
+                    subtitle=f"{action} for {domain} has no configurable parameters",
+                    valid=False,
+                )
+            )
+        else:
+            items.append(
+                AlfredItem(
+                    title=f"Set parameters for {action.replace('_', ' ')}",
+                    subtitle="Type key:value pairs (e.g. brightness:50%,transition:2)",
+                    icon=AlfredIcon(path=dc.icon_path),
+                    valid=False,
+                )
+            )
+            for p in params:
+                req = " (required)" if p.required else ""
+                items.append(
+                    AlfredItem(
+                        title=f"{p.label}{req}",
+                        subtitle=(
+                            f"{p.name}:<value> \u00b7 {p.hint}"
+                            if p.hint
+                            else f"{p.name}:<value>"
+                        ),
+                        icon=AlfredIcon(path=dc.icon_path),
+                        valid=False,
+                        autocomplete=f"{p.name}:",
+                    )
+                )
+    else:
+        # Try to parse the query as params
+        try:
+            parsed = parse_service_params(query, domain, action)
+        except ValueError as exc:
+            items.append(
+                AlfredItem(
+                    title="Invalid parameters",
+                    subtitle=str(exc),
+                    icon=AlfredIcon(path=dc.icon_path),
+                    valid=False,
+                )
+            )
+        else:
+            if not parsed:
+                items.append(
+                    AlfredItem(
+                        title="No parameters parsed",
+                        subtitle="Type key:value pairs separated by commas",
+                        valid=False,
+                    )
+                )
+            else:
+                summary = ", ".join(f"{k}={v}" for k, v in parsed.items())
+                items.append(
+                    AlfredItem(
+                        title=f"{action.replace('_', ' ').title()} {friendly}",
+                        subtitle=summary,
+                        icon=AlfredIcon(path=dc.icon_path),
+                        variables={
+                            "entity_id": entity_id,
+                            "action": action,
+                            "domain": domain,
+                            "params": query,
+                        },
+                        valid=True,
+                    )
+                )
 
     output = AlfredOutput(items=items)
     sys.stdout.write(output.to_json() + "\n")
@@ -1105,6 +1246,8 @@ def main(argv: Optional[list[str]] = None) -> None:
         _cmd_action(args[1:])
     elif command == "actions":
         _cmd_actions(args[1:])
+    elif command == "action-param":
+        _cmd_action_param(args[1:])
     elif command == "record-usage":
         entity_id = args[1] if len(args) > 1 else ""
         _cmd_record_usage(entity_id)

--- a/src/ha_workflow/entities.py
+++ b/src/ha_workflow/entities.py
@@ -215,7 +215,7 @@ DOMAIN_REGISTRY: dict[str, DomainConfig] = {
     ),
     "media_player": _DC(
         "toggle",
-        ("toggle", "media_play", "media_pause", "media_stop"),
+        ("toggle", "media_play", "media_pause", "media_stop", "volume_set"),
         "icons/media_player.png",
         _media_player_subtitle,
     ),
@@ -237,12 +237,20 @@ DOMAIN_REGISTRY: dict[str, DomainConfig] = {
     "person": _DC("", (), "icons/person.png", _default_subtitle),
     "zone": _DC("", (), "icons/zone.png", _default_subtitle),
     # Input helpers
-    "input_number": _DC("", (), "icons/input_number.png", _sensor_subtitle),
-    "input_select": _DC("", (), "icons/input_select.png", _default_subtitle),
-    "input_text": _DC("", (), "icons/input_text.png", _default_subtitle),
+    "input_number": _DC(
+        "set_value", ("set_value",), "icons/input_number.png", _sensor_subtitle
+    ),
+    "input_select": _DC(
+        "select_option", ("select_option",), "icons/input_select.png", _default_subtitle
+    ),
+    "input_text": _DC(
+        "set_value", ("set_value",), "icons/input_text.png", _default_subtitle
+    ),
     "input_datetime": _DC("", (), "icons/input_datetime.png", _default_subtitle),
-    "number": _DC("", (), "icons/number.png", _sensor_subtitle),
-    "select": _DC("", (), "icons/select.png", _default_subtitle),
+    "number": _DC("set_value", ("set_value",), "icons/number.png", _sensor_subtitle),
+    "select": _DC(
+        "select_option", ("select_option",), "icons/select.png", _default_subtitle
+    ),
     # Action entities
     "button": _DC("press", ("press",), "icons/button.png", _default_subtitle),
     "timer": _DC(
@@ -269,3 +277,84 @@ _UNKNOWN_DOMAIN = DomainConfig(
 def get_domain_config(domain: str) -> DomainConfig:
     """Return the :class:`DomainConfig` for *domain*, with a safe fallback."""
     return DOMAIN_REGISTRY.get(domain, _UNKNOWN_DOMAIN)
+
+
+# ---------------------------------------------------------------------------
+# Action parameter definitions
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ActionParam:
+    """Describes a single parameter for a parameterized HA service call."""
+
+    name: str  # HA service_data key (e.g. "brightness")
+    label: str  # Human-readable label ("Brightness")
+    type: str  # "int", "float", "str", "bool"
+    required: bool = False
+    min_value: Optional[float] = None
+    max_value: Optional[float] = None
+    hint: str = ""  # shown as Alfred subtitle ("0-255 or 0-100%")
+
+
+_AP = ActionParam  # shorthand
+
+ACTION_PARAMS: dict[tuple[str, str], tuple[ActionParam, ...]] = {
+    # --- Lights ---
+    ("light", "turn_on"): (
+        _AP("brightness", "Brightness", "int", hint="0-255 or 0-100%"),
+        _AP("color_temp_kelvin", "Color Temp", "int", hint="2000-6500 K"),
+        _AP("rgb_color", "RGB Color", "str", hint="R,G,B (e.g. 255,0,0)"),
+        _AP("color_name", "Color Name", "str", hint="e.g. red, blue, warm_white"),
+        _AP("effect", "Effect", "str", hint="Effect name"),
+        _AP("transition", "Transition", "float", hint="Seconds"),
+    ),
+    # --- Climate ---
+    ("climate", "set_temperature"): (
+        _AP("temperature", "Temperature", "float", required=True, hint="Target temp"),
+        _AP("hvac_mode", "HVAC Mode", "str", hint="heat, cool, auto, off"),
+    ),
+    # --- Cover ---
+    ("cover", "open_cover"): (
+        _AP("position", "Position", "int", hint="0-100%", min_value=0, max_value=100),
+    ),
+    ("cover", "close_cover"): (
+        _AP("position", "Position", "int", hint="0-100%", min_value=0, max_value=100),
+    ),
+    # --- Fan ---
+    ("fan", "turn_on"): (
+        _AP("percentage", "Speed", "int", hint="0-100%", min_value=0, max_value=100),
+    ),
+    # --- Media player ---
+    ("media_player", "volume_set"): (
+        _AP(
+            "volume_level",
+            "Volume",
+            "float",
+            hint="0.0-1.0",
+            min_value=0.0,
+            max_value=1.0,
+        ),
+    ),
+    # --- Input helpers ---
+    ("input_number", "set_value"): (
+        _AP("value", "Value", "float", required=True, hint="New value"),
+    ),
+    ("input_select", "select_option"): (
+        _AP("option", "Option", "str", required=True, hint="Option to select"),
+    ),
+    ("input_text", "set_value"): (
+        _AP("value", "Value", "str", required=True, hint="New text"),
+    ),
+    ("number", "set_value"): (
+        _AP("value", "Value", "float", required=True, hint="New value"),
+    ),
+    ("select", "select_option"): (
+        _AP("option", "Option", "str", required=True, hint="Option to select"),
+    ),
+}
+
+
+def get_action_params(domain: str, action: str) -> tuple[ActionParam, ...]:
+    """Return parameter definitions for a domain/action pair, or empty tuple."""
+    return ACTION_PARAMS.get((domain, action), ())

--- a/src/ha_workflow/entities.py
+++ b/src/ha_workflow/entities.py
@@ -316,14 +316,14 @@ ACTION_PARAMS: dict[tuple[str, str], tuple[ActionParam, ...]] = {
     ),
     # --- Cover ---
     ("cover", "open_cover"): (
-        _AP("position", "Position", "int", hint="0-100%", min_value=0, max_value=100),
+        _AP("position", "Position", "int", hint="0-100", min_value=0, max_value=100),
     ),
     ("cover", "close_cover"): (
-        _AP("position", "Position", "int", hint="0-100%", min_value=0, max_value=100),
+        _AP("position", "Position", "int", hint="0-100", min_value=0, max_value=100),
     ),
     # --- Fan ---
     ("fan", "turn_on"): (
-        _AP("percentage", "Speed", "int", hint="0-100%", min_value=0, max_value=100),
+        _AP("percentage", "Speed", "int", hint="0-100", min_value=0, max_value=100),
     ),
     # --- Media player ---
     ("media_player", "volume_set"): (

--- a/src/ha_workflow/params.py
+++ b/src/ha_workflow/params.py
@@ -1,0 +1,162 @@
+"""Parse short-syntax service parameters (e.g. ``brightness:50,transition:2``)."""
+
+from __future__ import annotations
+
+import math
+from typing import Optional, Union
+
+from ha_workflow.entities import get_action_params
+
+# Type produced by the parser — values are coerced to their declared types.
+ParamValue = Union[int, float, str, bool]
+
+
+def parse_service_params(
+    raw: str,
+    domain: str,
+    action: str,
+) -> dict[str, object]:
+    """Parse ``key:value,key:value`` into a typed ``service_data`` dict.
+
+    Type coercion uses :func:`get_action_params` for the *(domain, action)*
+    pair.  Unknown keys are passed through as strings so power users can send
+    arbitrary HA service data.
+
+    Special handling:
+
+    * **brightness** — a trailing ``%`` converts the percentage (0-100) to the
+      HA 0-255 range.
+    * **rgb_color** — ``"255,0,0"`` is converted to ``[255, 0, 0]``.
+
+    Raises :class:`ValueError` on parse or validation failures.
+    """
+    if not raw or not raw.strip():
+        return {}
+
+    param_defs = {p.name: p for p in get_action_params(domain, action)}
+    result: dict[str, object] = {}
+
+    # Pre-extract rgb_color if present (its value contains commas)
+    remaining = raw
+    if "rgb_color:" in remaining:
+        before, rgb_rest = remaining.split("rgb_color:", 1)
+        rgb_val, after = _extract_rgb(rgb_rest)
+        result["rgb_color"] = rgb_val
+        # Reassemble remaining params without the rgb_color segment
+        parts = [p.strip() for p in [before.rstrip(",").strip(), after] if p.strip()]
+        remaining = ",".join(parts)
+
+    if not remaining.strip():
+        return result
+
+    for pair in remaining.split(","):
+        pair = pair.strip()
+        if not pair:
+            continue
+        if ":" not in pair:
+            raise ValueError(f"Invalid parameter (expected key:value): {pair!r}")
+        key, value = pair.split(":", 1)
+        key = key.strip()
+        value = value.strip()
+        if not key:
+            raise ValueError(f"Empty parameter name in: {pair!r}")
+
+        param_def = param_defs.get(key)
+        if param_def is None:
+            # Unknown key — pass through as string
+            result[key] = value
+            continue
+
+        result[key] = _coerce(key, value, param_def.type)
+
+        # Validate min/max
+        if param_def.min_value is not None or param_def.max_value is not None:
+            _validate_range(key, result[key], param_def.min_value, param_def.max_value)
+
+    return result
+
+
+def _coerce(key: str, value: str, type_name: str) -> ParamValue:
+    """Coerce *value* to the declared *type_name*."""
+    if type_name == "int":
+        return _coerce_int(key, value)
+    if type_name == "float":
+        return _coerce_float(key, value)
+    if type_name == "bool":
+        return value.lower() in ("true", "1", "yes", "on")
+    # str — pass through
+    return value
+
+
+def _coerce_int(key: str, value: str) -> int:
+    """Coerce to int, with brightness percentage shorthand."""
+    if key == "brightness" and value.endswith("%"):
+        pct_str = value[:-1]
+        try:
+            pct = float(pct_str)
+        except ValueError:
+            raise ValueError(f"Invalid brightness percentage: {value!r}") from None
+        if pct < 0 or pct > 100:
+            raise ValueError(f"Brightness percentage must be 0-100, got {pct}")
+        return math.ceil(pct / 100.0 * 255)
+    try:
+        return int(value)
+    except ValueError:
+        raise ValueError(f"Expected integer for '{key}', got {value!r}") from None
+
+
+def _coerce_float(key: str, value: str) -> float:
+    """Coerce to float."""
+    try:
+        return float(value)
+    except ValueError:
+        raise ValueError(f"Expected number for '{key}', got {value!r}") from None
+
+
+def _validate_range(
+    key: str,
+    value: object,
+    min_val: Optional[float],
+    max_val: Optional[float],
+) -> None:
+    """Raise ValueError if *value* is outside [min_val, max_val]."""
+    if not isinstance(value, (int, float)):
+        return
+    if min_val is not None and value < min_val:
+        raise ValueError(f"'{key}' must be >= {min_val}, got {value}")
+    if max_val is not None and value > max_val:
+        raise ValueError(f"'{key}' must be <= {max_val}, got {value}")
+
+
+def _extract_rgb(rgb_raw: str) -> tuple[list[int], str]:
+    """Extract an RGB triplet and return ``(rgb_list, remaining_params)``.
+
+    Consumes up to 3 comma-separated integer tokens from *rgb_raw*, stopping
+    when a ``key:value`` pair is encountered.
+    """
+    rgb_parts: list[str] = []
+    after_parts: list[str] = []
+    hit_next = False
+    for token in rgb_raw.split(","):
+        token = token.strip()
+        if hit_next or (":" in token and len(rgb_parts) >= 1):
+            hit_next = True
+            after_parts.append(token)
+        else:
+            rgb_parts.append(token)
+
+    if len(rgb_parts) != 3:
+        raise ValueError(
+            f"Expected 3 RGB values (R,G,B), got {len(rgb_parts)}: "
+            f"{','.join(rgb_parts)!r}"
+        )
+    try:
+        rgb = [int(p) for p in rgb_parts]
+    except ValueError:
+        raise ValueError(
+            f"RGB values must be integers, got: {','.join(rgb_parts)!r}"
+        ) from None
+    for i, v in enumerate(rgb):
+        if v < 0 or v > 255:
+            raise ValueError(f"RGB value {v} at position {i} must be 0-255")
+    return rgb, ",".join(after_parts)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1244,14 +1244,31 @@ class TestActionsCommand:
         assert "Invalid entity ID" in data["items"][0]["title"]
         assert data["items"][0]["valid"] is False
 
-    def test_submenu_includes_advanced_stub(self, capsys: object) -> None:
+    def test_submenu_includes_advanced_action_call(self, capsys: object) -> None:
         main(["actions", "light.living_room"])
         out = capsys.readouterr().out  # type: ignore[union-attr]
         data = json.loads(out)
-        stub = [i for i in data["items"] if i["title"] == "Advanced Action Call"]
-        assert len(stub) == 1
-        assert stub[0]["valid"] is False
-        assert "Coming soon" in stub[0]["subtitle"]
+        adv = [i for i in data["items"] if "Advanced Action Call" in i["title"]]
+        assert len(adv) == 1
+        assert adv[0]["valid"] is False
+        assert "brightness" in adv[0]["subtitle"].lower()
+
+    def test_submenu_parameterized_hint(self, capsys: object) -> None:
+        """Turn On action for lights shows param hints in subtitle."""
+        main(["actions", "light.living_room"])
+        out = capsys.readouterr().out  # type: ignore[union-attr]
+        data = json.loads(out)
+        turn_on = [i for i in data["items"] if i.get("title") == "Turn On"]
+        assert len(turn_on) == 1
+        assert "brightness" in turn_on[0]["subtitle"].lower()
+
+    def test_submenu_no_advanced_for_sensor(self, capsys: object) -> None:
+        """Sensors have no actions, so no Advanced Action Call."""
+        main(["actions", "sensor.temperature"])
+        out = capsys.readouterr().out  # type: ignore[union-attr]
+        data = json.loads(out)
+        adv = [i for i in data["items"] if "Advanced Action Call" in i.get("title", "")]
+        assert len(adv) == 0
 
     def test_submenu_copy_entity_id(self, capsys: object) -> None:
         main(["actions", "light.living_room"])
@@ -1268,6 +1285,118 @@ class TestActionsCommand:
         items = [i for i in data["items"] if i["title"] == "Open History"]
         assert len(items) == 1
         assert items[0]["variables"]["action"] == "open_history"
+
+
+# ---------------------------------------------------------------------------
+# Parameterized actions
+# ---------------------------------------------------------------------------
+
+
+class TestActionWithParams:
+    @patch("ha_workflow.cli._cmd_record_usage")
+    @patch("ha_workflow.cli.dispatch_action")
+    @patch("ha_workflow.cli.HAClient")
+    @patch("ha_workflow.cli.Config.from_env")
+    def test_inline_params_passed(
+        self,
+        mock_from_env: MagicMock,
+        mock_ha_client: MagicMock,
+        mock_dispatch: MagicMock,
+        mock_record: MagicMock,
+        capsys: object,
+    ) -> None:
+        from ha_workflow.actions import ActionResult
+
+        mock_from_env.return_value = MagicMock()
+        mock_dispatch.return_value = ActionResult(success=True, message="Turned on")
+        main(["action", "light.bedroom", "turn_on", "brightness:128"])
+        mock_dispatch.assert_called_once()
+        call_args = mock_dispatch.call_args
+        assert call_args[1]["service_data"] == {"brightness": 128}
+
+    @patch("ha_workflow.cli._cmd_record_usage")
+    @patch("ha_workflow.cli.dispatch_action")
+    @patch("ha_workflow.cli.HAClient")
+    @patch("ha_workflow.cli.Config.from_env")
+    def test_inline_multiple_params(
+        self,
+        mock_from_env: MagicMock,
+        mock_ha_client: MagicMock,
+        mock_dispatch: MagicMock,
+        mock_record: MagicMock,
+        capsys: object,
+    ) -> None:
+        from ha_workflow.actions import ActionResult
+
+        mock_from_env.return_value = MagicMock()
+        mock_dispatch.return_value = ActionResult(success=True, message="Turned on")
+        main(
+            [
+                "action",
+                "light.bedroom",
+                "turn_on",
+                "brightness:50%,transition:2",
+            ]
+        )
+        call_args = mock_dispatch.call_args
+        sd = call_args[1]["service_data"]
+        assert sd["brightness"] == 128
+        assert sd["transition"] == 2.0
+
+    def test_inline_invalid_params_shows_error(self, capsys: object) -> None:
+        main(["action", "light.bedroom", "turn_on", "brightness:abc"])
+        out = capsys.readouterr().out  # type: ignore[union-attr]
+        assert "integer" in out.lower()
+
+
+class TestActionParamCommand:
+    def test_empty_query_lists_params(self, capsys: object) -> None:
+        main(["action-param", "light.bedroom", "turn_on"])
+        out = capsys.readouterr().out  # type: ignore[union-attr]
+        data = json.loads(out)
+        titles = [i["title"] for i in data["items"]]
+        assert any("Brightness" in t for t in titles)
+        assert any("Color Temp" in t for t in titles)
+
+    def test_valid_query_shows_confirmation(self, capsys: object) -> None:
+        main(
+            [
+                "action-param",
+                "light.bedroom",
+                "turn_on",
+                "brightness:128",
+            ]
+        )
+        out = capsys.readouterr().out  # type: ignore[union-attr]
+        data = json.loads(out)
+        assert data["items"][0]["valid"] is True
+        assert "brightness=128" in data["items"][0]["subtitle"]
+
+    def test_invalid_query_shows_error(self, capsys: object) -> None:
+        main(
+            [
+                "action-param",
+                "light.bedroom",
+                "turn_on",
+                "brightness:abc",
+            ]
+        )
+        out = capsys.readouterr().out  # type: ignore[union-attr]
+        data = json.loads(out)
+        assert data["items"][0]["valid"] is False
+        assert "Invalid" in data["items"][0]["title"]
+
+    def test_no_params_available(self, capsys: object) -> None:
+        main(["action-param", "light.bedroom", "toggle"])
+        out = capsys.readouterr().out  # type: ignore[union-attr]
+        data = json.loads(out)
+        assert "No parameters" in data["items"][0]["title"]
+
+    def test_missing_entity(self, capsys: object) -> None:
+        main(["action-param"])
+        out = capsys.readouterr().out  # type: ignore[union-attr]
+        data = json.loads(out)
+        assert "Missing" in data["items"][0]["title"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -1,0 +1,151 @@
+"""Tests for ha_workflow.params — short-syntax parameter parser."""
+
+from __future__ import annotations
+
+import pytest
+
+from ha_workflow.params import parse_service_params
+
+
+class TestBasicParsing:
+    def test_single_int(self) -> None:
+        result = parse_service_params("brightness:128", "light", "turn_on")
+        assert result == {"brightness": 128}
+
+    def test_single_float(self) -> None:
+        result = parse_service_params("transition:2.5", "light", "turn_on")
+        assert result == {"transition": 2.5}
+
+    def test_single_string(self) -> None:
+        result = parse_service_params("effect:rainbow", "light", "turn_on")
+        assert result == {"effect": "rainbow"}
+
+    def test_multiple_params(self) -> None:
+        result = parse_service_params("brightness:128,transition:2", "light", "turn_on")
+        assert result == {"brightness": 128, "transition": 2.0}
+
+    def test_empty_string(self) -> None:
+        assert parse_service_params("", "light", "turn_on") == {}
+
+    def test_whitespace_only(self) -> None:
+        assert parse_service_params("   ", "light", "turn_on") == {}
+
+
+class TestBrightnessPercentage:
+    def test_percentage_50(self) -> None:
+        result = parse_service_params("brightness:50%", "light", "turn_on")
+        assert result == {"brightness": 128}  # ceil(50/100 * 255)
+
+    def test_percentage_100(self) -> None:
+        result = parse_service_params("brightness:100%", "light", "turn_on")
+        assert result == {"brightness": 255}
+
+    def test_percentage_0(self) -> None:
+        result = parse_service_params("brightness:0%", "light", "turn_on")
+        assert result == {"brightness": 0}
+
+    def test_percentage_out_of_range(self) -> None:
+        with pytest.raises(ValueError, match="0-100"):
+            parse_service_params("brightness:150%", "light", "turn_on")
+
+    def test_raw_int_passthrough(self) -> None:
+        # Without %, treat as raw 0-255 value
+        result = parse_service_params("brightness:200", "light", "turn_on")
+        assert result == {"brightness": 200}
+
+
+class TestRGBColor:
+    def test_rgb_basic(self) -> None:
+        result = parse_service_params("rgb_color:255,0,128", "light", "turn_on")
+        assert result == {"rgb_color": [255, 0, 128]}
+
+    def test_rgb_with_other_params(self) -> None:
+        result = parse_service_params(
+            "rgb_color:255,0,0,transition:2", "light", "turn_on"
+        )
+        # rgb_color parser stops at transition:2 (has colon)
+        assert result["rgb_color"] == [255, 0, 0]
+        assert result["transition"] == 2.0
+
+    def test_rgb_wrong_count(self) -> None:
+        with pytest.raises(ValueError, match="3 RGB"):
+            parse_service_params("rgb_color:255,0", "light", "turn_on")
+
+    def test_rgb_out_of_range(self) -> None:
+        with pytest.raises(ValueError, match="0-255"):
+            parse_service_params("rgb_color:256,0,0", "light", "turn_on")
+
+
+class TestTypeCoercion:
+    def test_invalid_int(self) -> None:
+        with pytest.raises(ValueError, match="integer"):
+            parse_service_params("brightness:abc", "light", "turn_on")
+
+    def test_invalid_float(self) -> None:
+        with pytest.raises(ValueError, match="number"):
+            parse_service_params("temperature:warm", "climate", "set_temperature")
+
+    def test_climate_temperature(self) -> None:
+        result = parse_service_params("temperature:22.5", "climate", "set_temperature")
+        assert result == {"temperature": 22.5}
+
+
+class TestMinMaxValidation:
+    def test_fan_speed_valid(self) -> None:
+        result = parse_service_params("percentage:75", "fan", "turn_on")
+        assert result == {"percentage": 75}
+
+    def test_fan_speed_too_high(self) -> None:
+        with pytest.raises(ValueError, match="<= 100"):
+            parse_service_params("percentage:150", "fan", "turn_on")
+
+    def test_fan_speed_too_low(self) -> None:
+        with pytest.raises(ValueError, match=">= 0"):
+            parse_service_params("percentage:-5", "fan", "turn_on")
+
+    def test_volume_valid(self) -> None:
+        result = parse_service_params("volume_level:0.5", "media_player", "volume_set")
+        assert result == {"volume_level": 0.5}
+
+    def test_volume_too_high(self) -> None:
+        with pytest.raises(ValueError, match=r"<= 1\.0"):
+            parse_service_params("volume_level:1.5", "media_player", "volume_set")
+
+
+class TestUnknownKeys:
+    def test_unknown_key_passthrough(self) -> None:
+        result = parse_service_params("custom_attr:hello", "light", "turn_on")
+        assert result == {"custom_attr": "hello"}
+
+    def test_unknown_domain_action(self) -> None:
+        result = parse_service_params("foo:bar", "unknown_domain", "unknown_action")
+        assert result == {"foo": "bar"}
+
+
+class TestMalformedInput:
+    def test_no_colon(self) -> None:
+        with pytest.raises(ValueError, match="key:value"):
+            parse_service_params("brightness", "light", "turn_on")
+
+    def test_empty_key(self) -> None:
+        with pytest.raises(ValueError, match="Empty parameter"):
+            parse_service_params(":50", "light", "turn_on")
+
+    def test_value_with_colon(self) -> None:
+        # Value can contain colons (split on first only)
+        result = parse_service_params("effect:color:loop", "light", "turn_on")
+        assert result == {"effect": "color:loop"}
+
+
+class TestInputHelpers:
+    def test_input_number(self) -> None:
+        result = parse_service_params("value:42.5", "input_number", "set_value")
+        assert result == {"value": 42.5}
+
+    def test_input_select(self) -> None:
+        result = parse_service_params("option:morning", "input_select", "select_option")
+        assert result == {"option": "morning"}
+
+    def test_input_text(self) -> None:
+        result = parse_service_params("value:hello world", "input_text", "set_value")
+        assert result == {"value": "hello world"}


### PR DESCRIPTION
## Summary

- **Short syntax parser** (`params.py`): parse `brightness:50%,transition:2,color_name:blue` into typed service_data with coercion, validation, brightness % conversion, and RGB color support
- **Inline params in CLI**: `cli.py action light.bedroom turn_on brightness:128,transition:2` passes service_data through to HA
- **Interactive entry** (`action-param` command): Alfred query continuation flow — lists available parameters, validates input, shows confirmation item
- **Sub-menu enhancements**: parameterized actions show supported parameter hints; "Advanced Action Call" stub replaced with real entry
- **Domain registry updates**: input helpers (input_number, input_select, input_text, number, select) now have set_value/select_option actions; media_player gains volume_set

## Test plan

- [x] 31 new parser tests (type coercion, percentage, RGB, min/max, malformed input)
- [x] CLI tests: inline params, action-param empty/valid/invalid/missing queries
- [x] Sub-menu tests: param hints, advanced action call, sensor exclusion
- [x] Full suite: 366 passed, 4 skipped
- [x] ruff check, ruff format, mypy strict all pass
- [ ] Manual: test `action-param` flow in Alfred after wiring Script Filter node

🤖 Generated with [Claude Code](https://claude.com/claude-code)