### PR TITLE
feat: quick-exec entity service calls from the search bar

### DIFF
--- a/packages/ha_lib/cache.py
+++ b/packages/ha_lib/cache.py
@@ -108,6 +108,17 @@ class EntityCache:
         )
         return [self._row_to_entity(row) for row in cur.fetchall()]
 
+    def get_by_entity_id(self, entity_id: str) -> Optional[Entity]:
+        """Return the cached entity with *entity_id*, or ``None`` if missing."""
+        cur = self._conn.execute(
+            "SELECT entity_id, domain, state, friendly_name, "
+            "attributes_json, last_changed, last_updated, area_name, device_id "
+            "FROM entities WHERE entity_id = ?",
+            (entity_id,),
+        )
+        row = cur.fetchone()
+        return self._row_to_entity(row) if row else None
+
     def get_by_domain(self, domain: str) -> list[Entity]:
         """Return all cached entities in the given *domain*."""
         cur = self._conn.execute(

--- a/packages/ha_lib/colors.py
+++ b/packages/ha_lib/colors.py
@@ -1,0 +1,41 @@
+"""Named-color resolution.
+
+Maps human-friendly color names (CSS4 + X11 + XKCD + HA extras) to RGB
+triplets.  The bundled JSON is built by ``scripts/build_colors.py``.
+
+Resolution is permissive: names are lowercased and spaces, dashes, and
+underscores are all treated as the same separator, so ``"warm white"``,
+``"warm-white"``, and ``"warm_white"`` all resolve to the same color.
+"""
+
+from __future__ import annotations
+
+import json
+from functools import lru_cache
+from pathlib import Path
+from typing import Optional
+
+_DATA_PATH = Path(__file__).parent / "data" / "colors.json"
+
+
+def _normalize(name: str) -> str:
+    return name.strip().lower().replace("-", "_").replace(" ", "_")
+
+
+@lru_cache(maxsize=1)
+def _palette() -> dict[str, tuple[int, int, int]]:
+    with _DATA_PATH.open("r", encoding="utf-8") as f:
+        raw = json.load(f)
+    return {name: (r, g, b) for name, (r, g, b) in raw.items()}
+
+
+def resolve_color(name: str) -> Optional[tuple[int, int, int]]:
+    """Return ``(r, g, b)`` for *name*, or ``None`` if unknown."""
+    if not name:
+        return None
+    return _palette().get(_normalize(name))
+
+
+def palette_size() -> int:
+    """Number of known color names (useful in tests)."""
+    return len(_palette())

--- a/packages/ha_lib/data/colors.json
+++ b/packages/ha_lib/data/colors.json
@@ -1,0 +1,5262 @@
+{
+  "acid_green": [
+    143,
+    254,
+    9
+  ],
+  "adobe": [
+    189,
+    108,
+    72
+  ],
+  "algae": [
+    84,
+    172,
+    104
+  ],
+  "algae_green": [
+    33,
+    195,
+    111
+  ],
+  "aliceblue": [
+    240,
+    248,
+    255
+  ],
+  "almost_black": [
+    7,
+    13,
+    13
+  ],
+  "amber": [
+    254,
+    179,
+    8
+  ],
+  "amethyst": [
+    155,
+    95,
+    192
+  ],
+  "antiquewhite": [
+    250,
+    235,
+    215
+  ],
+  "apple": [
+    110,
+    203,
+    60
+  ],
+  "apple_green": [
+    118,
+    205,
+    38
+  ],
+  "apricot": [
+    255,
+    177,
+    109
+  ],
+  "aqua": [
+    0,
+    255,
+    255
+  ],
+  "aqua_blue": [
+    2,
+    216,
+    233
+  ],
+  "aqua_green": [
+    18,
+    225,
+    147
+  ],
+  "aqua_marine": [
+    46,
+    232,
+    187
+  ],
+  "aquamarine": [
+    127,
+    255,
+    212
+  ],
+  "army_green": [
+    75,
+    93,
+    22
+  ],
+  "asparagus": [
+    119,
+    171,
+    86
+  ],
+  "aubergine": [
+    61,
+    7,
+    52
+  ],
+  "auburn": [
+    154,
+    48,
+    1
+  ],
+  "avocado": [
+    144,
+    177,
+    52
+  ],
+  "avocado_green": [
+    135,
+    169,
+    34
+  ],
+  "azul": [
+    29,
+    93,
+    236
+  ],
+  "azure": [
+    240,
+    255,
+    255
+  ],
+  "baby_blue": [
+    162,
+    207,
+    254
+  ],
+  "baby_green": [
+    140,
+    255,
+    158
+  ],
+  "baby_pink": [
+    255,
+    183,
+    206
+  ],
+  "baby_poo": [
+    171,
+    144,
+    4
+  ],
+  "baby_poop": [
+    147,
+    124,
+    0
+  ],
+  "baby_poop_green": [
+    143,
+    152,
+    5
+  ],
+  "baby_puke_green": [
+    182,
+    196,
+    6
+  ],
+  "baby_purple": [
+    202,
+    155,
+    247
+  ],
+  "baby_shit_brown": [
+    173,
+    144,
+    13
+  ],
+  "baby_shit_green": [
+    136,
+    151,
+    23
+  ],
+  "banana": [
+    255,
+    255,
+    126
+  ],
+  "banana_yellow": [
+    250,
+    254,
+    75
+  ],
+  "barbie_pink": [
+    254,
+    70,
+    165
+  ],
+  "barf_green": [
+    148,
+    172,
+    2
+  ],
+  "barney": [
+    172,
+    29,
+    184
+  ],
+  "barney_purple": [
+    160,
+    4,
+    152
+  ],
+  "battleship_grey": [
+    107,
+    124,
+    133
+  ],
+  "beige": [
+    245,
+    245,
+    220
+  ],
+  "berry": [
+    153,
+    15,
+    75
+  ],
+  "bile": [
+    181,
+    195,
+    6
+  ],
+  "bisque": [
+    255,
+    228,
+    196
+  ],
+  "black": [
+    0,
+    0,
+    0
+  ],
+  "blanchedalmond": [
+    255,
+    235,
+    205
+  ],
+  "bland": [
+    175,
+    168,
+    139
+  ],
+  "blood": [
+    119,
+    0,
+    1
+  ],
+  "blood_orange": [
+    254,
+    75,
+    3
+  ],
+  "blood_red": [
+    152,
+    0,
+    2
+  ],
+  "blue": [
+    0,
+    0,
+    255
+  ],
+  "blue/green": [
+    15,
+    155,
+    142
+  ],
+  "blue/grey": [
+    117,
+    141,
+    163
+  ],
+  "blue/purple": [
+    90,
+    6,
+    239
+  ],
+  "blue_blue": [
+    34,
+    66,
+    199
+  ],
+  "blue_green": [
+    19,
+    126,
+    109
+  ],
+  "blue_grey": [
+    96,
+    124,
+    142
+  ],
+  "blue_purple": [
+    87,
+    41,
+    206
+  ],
+  "blue_violet": [
+    93,
+    6,
+    233
+  ],
+  "blue_with_a_hint_of_purple": [
+    83,
+    60,
+    198
+  ],
+  "blueberry": [
+    70,
+    65,
+    150
+  ],
+  "bluegreen": [
+    1,
+    122,
+    121
+  ],
+  "bluegrey": [
+    133,
+    163,
+    178
+  ],
+  "blueviolet": [
+    138,
+    43,
+    226
+  ],
+  "bluey_green": [
+    43,
+    177,
+    121
+  ],
+  "bluey_grey": [
+    137,
+    160,
+    176
+  ],
+  "bluey_purple": [
+    98,
+    65,
+    199
+  ],
+  "bluish": [
+    41,
+    118,
+    187
+  ],
+  "bluish_green": [
+    16,
+    166,
+    116
+  ],
+  "bluish_grey": [
+    116,
+    139,
+    151
+  ],
+  "bluish_purple": [
+    112,
+    59,
+    231
+  ],
+  "blurple": [
+    85,
+    57,
+    204
+  ],
+  "blush": [
+    242,
+    158,
+    142
+  ],
+  "blush_pink": [
+    254,
+    130,
+    140
+  ],
+  "booger": [
+    155,
+    181,
+    60
+  ],
+  "booger_green": [
+    150,
+    180,
+    3
+  ],
+  "bordeaux": [
+    123,
+    0,
+    44
+  ],
+  "boring_green": [
+    99,
+    179,
+    101
+  ],
+  "bottle_green": [
+    4,
+    74,
+    5
+  ],
+  "brick": [
+    160,
+    54,
+    35
+  ],
+  "brick_orange": [
+    193,
+    74,
+    9
+  ],
+  "brick_red": [
+    143,
+    20,
+    2
+  ],
+  "bright_aqua": [
+    11,
+    249,
+    234
+  ],
+  "bright_blue": [
+    1,
+    101,
+    252
+  ],
+  "bright_cyan": [
+    65,
+    253,
+    254
+  ],
+  "bright_green": [
+    1,
+    255,
+    7
+  ],
+  "bright_lavender": [
+    199,
+    96,
+    255
+  ],
+  "bright_light_blue": [
+    38,
+    247,
+    253
+  ],
+  "bright_light_green": [
+    45,
+    254,
+    84
+  ],
+  "bright_lilac": [
+    201,
+    94,
+    251
+  ],
+  "bright_lime": [
+    135,
+    253,
+    5
+  ],
+  "bright_lime_green": [
+    101,
+    254,
+    8
+  ],
+  "bright_magenta": [
+    255,
+    8,
+    232
+  ],
+  "bright_olive": [
+    156,
+    187,
+    4
+  ],
+  "bright_orange": [
+    255,
+    91,
+    0
+  ],
+  "bright_pink": [
+    254,
+    1,
+    177
+  ],
+  "bright_purple": [
+    190,
+    3,
+    253
+  ],
+  "bright_red": [
+    255,
+    0,
+    13
+  ],
+  "bright_sea_green": [
+    5,
+    255,
+    166
+  ],
+  "bright_sky_blue": [
+    2,
+    204,
+    254
+  ],
+  "bright_teal": [
+    1,
+    249,
+    198
+  ],
+  "bright_turquoise": [
+    15,
+    254,
+    249
+  ],
+  "bright_violet": [
+    173,
+    10,
+    253
+  ],
+  "bright_yellow": [
+    255,
+    253,
+    1
+  ],
+  "bright_yellow_green": [
+    157,
+    255,
+    0
+  ],
+  "british_racing_green": [
+    5,
+    72,
+    13
+  ],
+  "bronze": [
+    168,
+    121,
+    0
+  ],
+  "brown": [
+    165,
+    42,
+    42
+  ],
+  "brown_green": [
+    112,
+    108,
+    17
+  ],
+  "brown_grey": [
+    141,
+    132,
+    104
+  ],
+  "brown_orange": [
+    185,
+    105,
+    2
+  ],
+  "brown_red": [
+    146,
+    43,
+    5
+  ],
+  "brown_yellow": [
+    178,
+    151,
+    5
+  ],
+  "brownish": [
+    156,
+    109,
+    87
+  ],
+  "brownish_green": [
+    106,
+    110,
+    9
+  ],
+  "brownish_grey": [
+    134,
+    119,
+    95
+  ],
+  "brownish_orange": [
+    203,
+    119,
+    35
+  ],
+  "brownish_pink": [
+    194,
+    126,
+    121
+  ],
+  "brownish_purple": [
+    118,
+    66,
+    78
+  ],
+  "brownish_red": [
+    158,
+    54,
+    35
+  ],
+  "brownish_yellow": [
+    201,
+    176,
+    3
+  ],
+  "browny_green": [
+    111,
+    108,
+    10
+  ],
+  "browny_orange": [
+    202,
+    107,
+    2
+  ],
+  "bruise": [
+    126,
+    64,
+    113
+  ],
+  "bubble_gum_pink": [
+    255,
+    105,
+    175
+  ],
+  "bubblegum": [
+    255,
+    108,
+    181
+  ],
+  "bubblegum_pink": [
+    254,
+    131,
+    204
+  ],
+  "buff": [
+    254,
+    246,
+    158
+  ],
+  "burgundy": [
+    97,
+    0,
+    35
+  ],
+  "burlywood": [
+    222,
+    184,
+    135
+  ],
+  "burnt_orange": [
+    192,
+    78,
+    1
+  ],
+  "burnt_red": [
+    159,
+    35,
+    5
+  ],
+  "burnt_siena": [
+    183,
+    82,
+    3
+  ],
+  "burnt_sienna": [
+    176,
+    78,
+    15
+  ],
+  "burnt_umber": [
+    160,
+    69,
+    14
+  ],
+  "burnt_yellow": [
+    213,
+    171,
+    9
+  ],
+  "burple": [
+    104,
+    50,
+    227
+  ],
+  "butter": [
+    255,
+    255,
+    129
+  ],
+  "butter_yellow": [
+    255,
+    253,
+    116
+  ],
+  "butterscotch": [
+    253,
+    177,
+    71
+  ],
+  "cadet_blue": [
+    78,
+    116,
+    150
+  ],
+  "cadetblue": [
+    95,
+    158,
+    160
+  ],
+  "camel": [
+    198,
+    159,
+    89
+  ],
+  "camo": [
+    127,
+    143,
+    78
+  ],
+  "camo_green": [
+    82,
+    101,
+    37
+  ],
+  "camouflage_green": [
+    75,
+    97,
+    19
+  ],
+  "canary": [
+    253,
+    255,
+    99
+  ],
+  "canary_yellow": [
+    255,
+    254,
+    64
+  ],
+  "candy_pink": [
+    255,
+    99,
+    233
+  ],
+  "caramel": [
+    175,
+    111,
+    9
+  ],
+  "carmine": [
+    157,
+    2,
+    22
+  ],
+  "carnation": [
+    253,
+    121,
+    143
+  ],
+  "carnation_pink": [
+    255,
+    127,
+    167
+  ],
+  "carolina_blue": [
+    138,
+    184,
+    254
+  ],
+  "celadon": [
+    190,
+    253,
+    183
+  ],
+  "celery": [
+    193,
+    253,
+    149
+  ],
+  "cement": [
+    165,
+    163,
+    145
+  ],
+  "cerise": [
+    222,
+    12,
+    98
+  ],
+  "cerulean": [
+    4,
+    133,
+    209
+  ],
+  "cerulean_blue": [
+    5,
+    110,
+    238
+  ],
+  "charcoal": [
+    52,
+    56,
+    55
+  ],
+  "charcoal_grey": [
+    60,
+    65,
+    66
+  ],
+  "chartreuse": [
+    127,
+    255,
+    0
+  ],
+  "cherry": [
+    207,
+    2,
+    52
+  ],
+  "cherry_red": [
+    247,
+    2,
+    42
+  ],
+  "chestnut": [
+    116,
+    40,
+    2
+  ],
+  "chocolate": [
+    210,
+    105,
+    30
+  ],
+  "chocolate_brown": [
+    65,
+    25,
+    0
+  ],
+  "cinnamon": [
+    172,
+    79,
+    6
+  ],
+  "claret": [
+    104,
+    0,
+    24
+  ],
+  "clay": [
+    182,
+    106,
+    80
+  ],
+  "clay_brown": [
+    178,
+    113,
+    61
+  ],
+  "clear_blue": [
+    36,
+    122,
+    253
+  ],
+  "cloudy_blue": [
+    172,
+    194,
+    217
+  ],
+  "cobalt": [
+    30,
+    72,
+    143
+  ],
+  "cobalt_blue": [
+    3,
+    10,
+    167
+  ],
+  "cocoa": [
+    135,
+    95,
+    66
+  ],
+  "coffee": [
+    166,
+    129,
+    76
+  ],
+  "cool_blue": [
+    73,
+    132,
+    184
+  ],
+  "cool_green": [
+    51,
+    184,
+    100
+  ],
+  "cool_grey": [
+    149,
+    163,
+    166
+  ],
+  "cool_white": [
+    245,
+    245,
+    245
+  ],
+  "copper": [
+    182,
+    99,
+    37
+  ],
+  "coral": [
+    255,
+    127,
+    80
+  ],
+  "coral_pink": [
+    255,
+    97,
+    99
+  ],
+  "cornflower": [
+    106,
+    121,
+    247
+  ],
+  "cornflower_blue": [
+    81,
+    112,
+    215
+  ],
+  "cornflowerblue": [
+    100,
+    149,
+    237
+  ],
+  "cornsilk": [
+    255,
+    248,
+    220
+  ],
+  "cranberry": [
+    158,
+    0,
+    58
+  ],
+  "cream": [
+    255,
+    255,
+    194
+  ],
+  "creme": [
+    255,
+    255,
+    182
+  ],
+  "crimson": [
+    220,
+    20,
+    60
+  ],
+  "custard": [
+    255,
+    253,
+    120
+  ],
+  "cyan": [
+    0,
+    255,
+    255
+  ],
+  "dandelion": [
+    254,
+    223,
+    8
+  ],
+  "dark": [
+    27,
+    36,
+    49
+  ],
+  "dark_aqua": [
+    5,
+    105,
+    107
+  ],
+  "dark_aquamarine": [
+    1,
+    115,
+    113
+  ],
+  "dark_beige": [
+    172,
+    147,
+    98
+  ],
+  "dark_blue": [
+    0,
+    3,
+    91
+  ],
+  "dark_blue_green": [
+    0,
+    82,
+    73
+  ],
+  "dark_blue_grey": [
+    31,
+    59,
+    77
+  ],
+  "dark_brown": [
+    52,
+    28,
+    2
+  ],
+  "dark_coral": [
+    207,
+    82,
+    78
+  ],
+  "dark_cream": [
+    255,
+    243,
+    154
+  ],
+  "dark_cyan": [
+    10,
+    136,
+    138
+  ],
+  "dark_forest_green": [
+    0,
+    45,
+    4
+  ],
+  "dark_fuchsia": [
+    157,
+    7,
+    89
+  ],
+  "dark_gold": [
+    181,
+    148,
+    16
+  ],
+  "dark_grass_green": [
+    56,
+    128,
+    4
+  ],
+  "dark_green": [
+    3,
+    53,
+    0
+  ],
+  "dark_green_blue": [
+    31,
+    99,
+    87
+  ],
+  "dark_grey": [
+    54,
+    55,
+    55
+  ],
+  "dark_grey_blue": [
+    41,
+    70,
+    91
+  ],
+  "dark_hot_pink": [
+    217,
+    1,
+    102
+  ],
+  "dark_indigo": [
+    31,
+    9,
+    84
+  ],
+  "dark_khaki": [
+    155,
+    143,
+    85
+  ],
+  "dark_lavender": [
+    133,
+    103,
+    152
+  ],
+  "dark_lilac": [
+    156,
+    109,
+    165
+  ],
+  "dark_lime": [
+    132,
+    183,
+    1
+  ],
+  "dark_lime_green": [
+    126,
+    189,
+    1
+  ],
+  "dark_magenta": [
+    150,
+    0,
+    86
+  ],
+  "dark_maroon": [
+    60,
+    0,
+    8
+  ],
+  "dark_mauve": [
+    135,
+    76,
+    98
+  ],
+  "dark_mint": [
+    72,
+    192,
+    114
+  ],
+  "dark_mint_green": [
+    32,
+    192,
+    115
+  ],
+  "dark_mustard": [
+    168,
+    137,
+    5
+  ],
+  "dark_navy": [
+    0,
+    4,
+    53
+  ],
+  "dark_navy_blue": [
+    0,
+    2,
+    46
+  ],
+  "dark_olive": [
+    55,
+    62,
+    2
+  ],
+  "dark_olive_green": [
+    60,
+    77,
+    3
+  ],
+  "dark_orange": [
+    198,
+    81,
+    2
+  ],
+  "dark_pastel_green": [
+    86,
+    174,
+    87
+  ],
+  "dark_peach": [
+    222,
+    126,
+    93
+  ],
+  "dark_periwinkle": [
+    102,
+    95,
+    209
+  ],
+  "dark_pink": [
+    203,
+    65,
+    107
+  ],
+  "dark_plum": [
+    63,
+    1,
+    44
+  ],
+  "dark_purple": [
+    53,
+    6,
+    62
+  ],
+  "dark_red": [
+    132,
+    0,
+    0
+  ],
+  "dark_rose": [
+    181,
+    72,
+    93
+  ],
+  "dark_royal_blue": [
+    2,
+    6,
+    111
+  ],
+  "dark_sage": [
+    89,
+    133,
+    86
+  ],
+  "dark_salmon": [
+    200,
+    90,
+    83
+  ],
+  "dark_sand": [
+    168,
+    143,
+    89
+  ],
+  "dark_sea_green": [
+    17,
+    135,
+    93
+  ],
+  "dark_seafoam": [
+    31,
+    181,
+    122
+  ],
+  "dark_seafoam_green": [
+    62,
+    175,
+    118
+  ],
+  "dark_sky_blue": [
+    68,
+    142,
+    228
+  ],
+  "dark_slate_blue": [
+    33,
+    71,
+    97
+  ],
+  "dark_tan": [
+    175,
+    136,
+    74
+  ],
+  "dark_taupe": [
+    127,
+    104,
+    78
+  ],
+  "dark_teal": [
+    1,
+    77,
+    78
+  ],
+  "dark_turquoise": [
+    4,
+    92,
+    90
+  ],
+  "dark_violet": [
+    52,
+    1,
+    63
+  ],
+  "dark_yellow": [
+    213,
+    182,
+    10
+  ],
+  "dark_yellow_green": [
+    114,
+    143,
+    2
+  ],
+  "darkblue": [
+    0,
+    0,
+    139
+  ],
+  "darkcyan": [
+    0,
+    139,
+    139
+  ],
+  "darkgoldenrod": [
+    184,
+    134,
+    11
+  ],
+  "darkgray": [
+    169,
+    169,
+    169
+  ],
+  "darkgreen": [
+    0,
+    100,
+    0
+  ],
+  "darkgrey": [
+    169,
+    169,
+    169
+  ],
+  "darkish_blue": [
+    1,
+    65,
+    130
+  ],
+  "darkish_green": [
+    40,
+    124,
+    55
+  ],
+  "darkish_pink": [
+    218,
+    70,
+    125
+  ],
+  "darkish_purple": [
+    117,
+    25,
+    115
+  ],
+  "darkish_red": [
+    169,
+    3,
+    8
+  ],
+  "darkkhaki": [
+    189,
+    183,
+    107
+  ],
+  "darkmagenta": [
+    139,
+    0,
+    139
+  ],
+  "darkolivegreen": [
+    85,
+    107,
+    47
+  ],
+  "darkorange": [
+    255,
+    140,
+    0
+  ],
+  "darkorchid": [
+    153,
+    50,
+    204
+  ],
+  "darkred": [
+    139,
+    0,
+    0
+  ],
+  "darksalmon": [
+    233,
+    150,
+    122
+  ],
+  "darkseagreen": [
+    143,
+    188,
+    143
+  ],
+  "darkslateblue": [
+    72,
+    61,
+    139
+  ],
+  "darkslategray": [
+    47,
+    79,
+    79
+  ],
+  "darkslategrey": [
+    47,
+    79,
+    79
+  ],
+  "darkturquoise": [
+    0,
+    206,
+    209
+  ],
+  "darkviolet": [
+    148,
+    0,
+    211
+  ],
+  "deep_aqua": [
+    8,
+    120,
+    127
+  ],
+  "deep_blue": [
+    4,
+    2,
+    115
+  ],
+  "deep_brown": [
+    65,
+    2,
+    0
+  ],
+  "deep_green": [
+    2,
+    89,
+    15
+  ],
+  "deep_lavender": [
+    141,
+    94,
+    183
+  ],
+  "deep_lilac": [
+    150,
+    110,
+    189
+  ],
+  "deep_magenta": [
+    160,
+    2,
+    92
+  ],
+  "deep_orange": [
+    220,
+    77,
+    1
+  ],
+  "deep_pink": [
+    203,
+    1,
+    98
+  ],
+  "deep_purple": [
+    54,
+    1,
+    63
+  ],
+  "deep_red": [
+    154,
+    2,
+    0
+  ],
+  "deep_rose": [
+    199,
+    71,
+    103
+  ],
+  "deep_sea_blue": [
+    1,
+    84,
+    130
+  ],
+  "deep_sky_blue": [
+    13,
+    117,
+    248
+  ],
+  "deep_teal": [
+    0,
+    85,
+    90
+  ],
+  "deep_turquoise": [
+    1,
+    115,
+    116
+  ],
+  "deep_violet": [
+    73,
+    6,
+    72
+  ],
+  "deeppink": [
+    255,
+    20,
+    147
+  ],
+  "deepskyblue": [
+    0,
+    191,
+    255
+  ],
+  "denim": [
+    59,
+    99,
+    140
+  ],
+  "denim_blue": [
+    59,
+    91,
+    146
+  ],
+  "desert": [
+    204,
+    173,
+    96
+  ],
+  "diarrhea": [
+    159,
+    131,
+    3
+  ],
+  "dimgray": [
+    105,
+    105,
+    105
+  ],
+  "dimgrey": [
+    105,
+    105,
+    105
+  ],
+  "dirt": [
+    138,
+    110,
+    69
+  ],
+  "dirt_brown": [
+    131,
+    101,
+    57
+  ],
+  "dirty_blue": [
+    63,
+    130,
+    157
+  ],
+  "dirty_green": [
+    102,
+    126,
+    44
+  ],
+  "dirty_orange": [
+    200,
+    118,
+    6
+  ],
+  "dirty_pink": [
+    202,
+    123,
+    128
+  ],
+  "dirty_purple": [
+    115,
+    74,
+    101
+  ],
+  "dirty_yellow": [
+    205,
+    197,
+    10
+  ],
+  "dodger_blue": [
+    62,
+    130,
+    252
+  ],
+  "dodgerblue": [
+    30,
+    144,
+    255
+  ],
+  "drab": [
+    130,
+    131,
+    68
+  ],
+  "drab_green": [
+    116,
+    149,
+    81
+  ],
+  "dried_blood": [
+    75,
+    1,
+    1
+  ],
+  "duck_egg_blue": [
+    195,
+    251,
+    244
+  ],
+  "dull_blue": [
+    73,
+    117,
+    156
+  ],
+  "dull_brown": [
+    135,
+    110,
+    75
+  ],
+  "dull_green": [
+    116,
+    166,
+    98
+  ],
+  "dull_orange": [
+    216,
+    134,
+    59
+  ],
+  "dull_pink": [
+    213,
+    134,
+    157
+  ],
+  "dull_purple": [
+    132,
+    89,
+    126
+  ],
+  "dull_red": [
+    187,
+    63,
+    63
+  ],
+  "dull_teal": [
+    95,
+    158,
+    143
+  ],
+  "dull_yellow": [
+    238,
+    220,
+    91
+  ],
+  "dusk": [
+    78,
+    84,
+    129
+  ],
+  "dusk_blue": [
+    38,
+    83,
+    141
+  ],
+  "dusky_blue": [
+    71,
+    95,
+    148
+  ],
+  "dusky_pink": [
+    204,
+    122,
+    139
+  ],
+  "dusky_purple": [
+    137,
+    91,
+    123
+  ],
+  "dusky_rose": [
+    186,
+    104,
+    115
+  ],
+  "dust": [
+    178,
+    153,
+    110
+  ],
+  "dusty_blue": [
+    90,
+    134,
+    173
+  ],
+  "dusty_green": [
+    118,
+    169,
+    115
+  ],
+  "dusty_lavender": [
+    172,
+    134,
+    168
+  ],
+  "dusty_orange": [
+    240,
+    131,
+    58
+  ],
+  "dusty_pink": [
+    213,
+    138,
+    148
+  ],
+  "dusty_purple": [
+    130,
+    95,
+    135
+  ],
+  "dusty_red": [
+    185,
+    72,
+    78
+  ],
+  "dusty_rose": [
+    192,
+    115,
+    122
+  ],
+  "dusty_teal": [
+    76,
+    144,
+    133
+  ],
+  "earth": [
+    162,
+    101,
+    62
+  ],
+  "easter_green": [
+    140,
+    253,
+    126
+  ],
+  "easter_purple": [
+    192,
+    113,
+    254
+  ],
+  "ecru": [
+    254,
+    255,
+    202
+  ],
+  "egg_shell": [
+    255,
+    252,
+    196
+  ],
+  "eggplant": [
+    56,
+    8,
+    53
+  ],
+  "eggplant_purple": [
+    67,
+    5,
+    65
+  ],
+  "eggshell": [
+    255,
+    255,
+    212
+  ],
+  "eggshell_blue": [
+    196,
+    255,
+    247
+  ],
+  "electric_blue": [
+    6,
+    82,
+    255
+  ],
+  "electric_green": [
+    33,
+    252,
+    13
+  ],
+  "electric_lime": [
+    168,
+    255,
+    4
+  ],
+  "electric_pink": [
+    255,
+    4,
+    144
+  ],
+  "electric_purple": [
+    170,
+    35,
+    255
+  ],
+  "emerald": [
+    1,
+    160,
+    73
+  ],
+  "emerald_green": [
+    2,
+    143,
+    30
+  ],
+  "evergreen": [
+    5,
+    71,
+    42
+  ],
+  "faded_blue": [
+    101,
+    140,
+    187
+  ],
+  "faded_green": [
+    123,
+    178,
+    116
+  ],
+  "faded_orange": [
+    240,
+    148,
+    77
+  ],
+  "faded_pink": [
+    222,
+    157,
+    172
+  ],
+  "faded_purple": [
+    145,
+    110,
+    153
+  ],
+  "faded_red": [
+    211,
+    73,
+    78
+  ],
+  "faded_yellow": [
+    254,
+    255,
+    127
+  ],
+  "fawn": [
+    207,
+    175,
+    123
+  ],
+  "fern": [
+    99,
+    169,
+    80
+  ],
+  "fern_green": [
+    84,
+    141,
+    68
+  ],
+  "fire_engine_red": [
+    254,
+    0,
+    2
+  ],
+  "firebrick": [
+    178,
+    34,
+    34
+  ],
+  "flat_blue": [
+    60,
+    115,
+    168
+  ],
+  "flat_green": [
+    105,
+    157,
+    76
+  ],
+  "floralwhite": [
+    255,
+    250,
+    240
+  ],
+  "fluorescent_green": [
+    8,
+    255,
+    8
+  ],
+  "fluro_green": [
+    10,
+    255,
+    2
+  ],
+  "foam_green": [
+    144,
+    253,
+    169
+  ],
+  "forest": [
+    11,
+    85,
+    9
+  ],
+  "forest_green": [
+    6,
+    71,
+    12
+  ],
+  "forestgreen": [
+    34,
+    139,
+    34
+  ],
+  "forrest_green": [
+    21,
+    68,
+    6
+  ],
+  "french_blue": [
+    67,
+    107,
+    173
+  ],
+  "fresh_green": [
+    105,
+    216,
+    79
+  ],
+  "frog_green": [
+    88,
+    188,
+    8
+  ],
+  "fuchsia": [
+    255,
+    0,
+    255
+  ],
+  "gainsboro": [
+    220,
+    220,
+    220
+  ],
+  "ghostwhite": [
+    248,
+    248,
+    255
+  ],
+  "gold": [
+    255,
+    215,
+    0
+  ],
+  "golden": [
+    245,
+    191,
+    3
+  ],
+  "golden_brown": [
+    178,
+    122,
+    1
+  ],
+  "golden_rod": [
+    249,
+    188,
+    8
+  ],
+  "golden_yellow": [
+    254,
+    198,
+    21
+  ],
+  "goldenrod": [
+    218,
+    165,
+    32
+  ],
+  "grape": [
+    108,
+    52,
+    97
+  ],
+  "grape_purple": [
+    93,
+    20,
+    81
+  ],
+  "grapefruit": [
+    253,
+    89,
+    86
+  ],
+  "grass": [
+    92,
+    172,
+    45
+  ],
+  "grass_green": [
+    63,
+    155,
+    11
+  ],
+  "grassy_green": [
+    65,
+    156,
+    3
+  ],
+  "gray": [
+    128,
+    128,
+    128
+  ],
+  "green": [
+    0,
+    128,
+    0
+  ],
+  "green/blue": [
+    1,
+    192,
+    141
+  ],
+  "green/yellow": [
+    181,
+    206,
+    8
+  ],
+  "green_apple": [
+    94,
+    220,
+    31
+  ],
+  "green_blue": [
+    6,
+    180,
+    139
+  ],
+  "green_brown": [
+    84,
+    78,
+    3
+  ],
+  "green_grey": [
+    119,
+    146,
+    111
+  ],
+  "green_teal": [
+    12,
+    181,
+    119
+  ],
+  "green_yellow": [
+    201,
+    255,
+    39
+  ],
+  "greenblue": [
+    35,
+    196,
+    139
+  ],
+  "greenish": [
+    64,
+    163,
+    104
+  ],
+  "greenish_beige": [
+    201,
+    209,
+    121
+  ],
+  "greenish_blue": [
+    11,
+    139,
+    135
+  ],
+  "greenish_brown": [
+    105,
+    97,
+    18
+  ],
+  "greenish_cyan": [
+    42,
+    254,
+    183
+  ],
+  "greenish_grey": [
+    150,
+    174,
+    141
+  ],
+  "greenish_tan": [
+    188,
+    203,
+    122
+  ],
+  "greenish_teal": [
+    50,
+    191,
+    132
+  ],
+  "greenish_turquoise": [
+    0,
+    251,
+    176
+  ],
+  "greenish_yellow": [
+    205,
+    253,
+    2
+  ],
+  "greeny_blue": [
+    66,
+    179,
+    149
+  ],
+  "greeny_brown": [
+    105,
+    96,
+    6
+  ],
+  "greeny_grey": [
+    126,
+    160,
+    122
+  ],
+  "greeny_yellow": [
+    198,
+    248,
+    8
+  ],
+  "greenyellow": [
+    173,
+    255,
+    47
+  ],
+  "grey": [
+    128,
+    128,
+    128
+  ],
+  "grey/blue": [
+    100,
+    125,
+    142
+  ],
+  "grey/green": [
+    134,
+    161,
+    125
+  ],
+  "grey_blue": [
+    107,
+    139,
+    164
+  ],
+  "grey_brown": [
+    127,
+    112,
+    83
+  ],
+  "grey_green": [
+    120,
+    155,
+    115
+  ],
+  "grey_pink": [
+    195,
+    144,
+    155
+  ],
+  "grey_purple": [
+    130,
+    109,
+    140
+  ],
+  "grey_teal": [
+    94,
+    155,
+    138
+  ],
+  "greyblue": [
+    119,
+    161,
+    181
+  ],
+  "greyish": [
+    168,
+    164,
+    149
+  ],
+  "greyish_blue": [
+    94,
+    129,
+    157
+  ],
+  "greyish_brown": [
+    122,
+    106,
+    79
+  ],
+  "greyish_green": [
+    130,
+    166,
+    125
+  ],
+  "greyish_pink": [
+    200,
+    141,
+    148
+  ],
+  "greyish_purple": [
+    136,
+    113,
+    145
+  ],
+  "greyish_teal": [
+    113,
+    159,
+    145
+  ],
+  "gross_green": [
+    160,
+    191,
+    22
+  ],
+  "gunmetal": [
+    83,
+    98,
+    103
+  ],
+  "hazel": [
+    142,
+    118,
+    24
+  ],
+  "heather": [
+    164,
+    132,
+    172
+  ],
+  "heliotrope": [
+    217,
+    79,
+    245
+  ],
+  "highlighter_green": [
+    27,
+    252,
+    6
+  ],
+  "homeassistant_blue": [
+    24,
+    188,
+    242
+  ],
+  "homeassistant_orange": [
+    24,
+    188,
+    242
+  ],
+  "honeydew": [
+    240,
+    255,
+    240
+  ],
+  "hospital_green": [
+    155,
+    229,
+    170
+  ],
+  "hot_green": [
+    37,
+    255,
+    41
+  ],
+  "hot_magenta": [
+    245,
+    4,
+    201
+  ],
+  "hot_pink": [
+    255,
+    2,
+    141
+  ],
+  "hot_purple": [
+    203,
+    0,
+    245
+  ],
+  "hotpink": [
+    255,
+    105,
+    180
+  ],
+  "hunter_green": [
+    11,
+    64,
+    8
+  ],
+  "ice": [
+    214,
+    255,
+    250
+  ],
+  "ice_blue": [
+    215,
+    255,
+    254
+  ],
+  "icky_green": [
+    143,
+    174,
+    34
+  ],
+  "indian_red": [
+    133,
+    14,
+    4
+  ],
+  "indianred": [
+    205,
+    92,
+    92
+  ],
+  "indigo": [
+    75,
+    0,
+    130
+  ],
+  "indigo_blue": [
+    58,
+    24,
+    177
+  ],
+  "iris": [
+    98,
+    88,
+    196
+  ],
+  "irish_green": [
+    1,
+    149,
+    41
+  ],
+  "ivory": [
+    255,
+    255,
+    240
+  ],
+  "jade": [
+    31,
+    167,
+    116
+  ],
+  "jade_green": [
+    43,
+    175,
+    106
+  ],
+  "jungle_green": [
+    4,
+    130,
+    67
+  ],
+  "kelley_green": [
+    0,
+    147,
+    55
+  ],
+  "kelly_green": [
+    2,
+    171,
+    46
+  ],
+  "kermit_green": [
+    92,
+    178,
+    0
+  ],
+  "key_lime": [
+    174,
+    255,
+    110
+  ],
+  "khaki": [
+    240,
+    230,
+    140
+  ],
+  "khaki_green": [
+    114,
+    134,
+    57
+  ],
+  "kiwi": [
+    156,
+    239,
+    67
+  ],
+  "kiwi_green": [
+    142,
+    229,
+    63
+  ],
+  "lavender": [
+    230,
+    230,
+    250
+  ],
+  "lavender_blue": [
+    139,
+    136,
+    248
+  ],
+  "lavender_pink": [
+    221,
+    133,
+    215
+  ],
+  "lavenderblush": [
+    255,
+    240,
+    245
+  ],
+  "lawn_green": [
+    77,
+    164,
+    9
+  ],
+  "lawngreen": [
+    124,
+    252,
+    0
+  ],
+  "leaf": [
+    113,
+    170,
+    52
+  ],
+  "leaf_green": [
+    92,
+    169,
+    4
+  ],
+  "leafy_green": [
+    81,
+    183,
+    59
+  ],
+  "leather": [
+    172,
+    116,
+    52
+  ],
+  "lemon": [
+    253,
+    255,
+    82
+  ],
+  "lemon_green": [
+    173,
+    248,
+    2
+  ],
+  "lemon_lime": [
+    191,
+    254,
+    40
+  ],
+  "lemon_yellow": [
+    253,
+    255,
+    56
+  ],
+  "lemonchiffon": [
+    255,
+    250,
+    205
+  ],
+  "lichen": [
+    143,
+    182,
+    123
+  ],
+  "light_aqua": [
+    140,
+    255,
+    219
+  ],
+  "light_aquamarine": [
+    123,
+    253,
+    199
+  ],
+  "light_beige": [
+    255,
+    254,
+    182
+  ],
+  "light_blue": [
+    149,
+    208,
+    252
+  ],
+  "light_blue_green": [
+    126,
+    251,
+    179
+  ],
+  "light_blue_grey": [
+    183,
+    201,
+    226
+  ],
+  "light_bluish_green": [
+    118,
+    253,
+    168
+  ],
+  "light_bright_green": [
+    83,
+    254,
+    92
+  ],
+  "light_brown": [
+    173,
+    129,
+    80
+  ],
+  "light_burgundy": [
+    168,
+    65,
+    91
+  ],
+  "light_cyan": [
+    172,
+    255,
+    252
+  ],
+  "light_eggplant": [
+    137,
+    69,
+    133
+  ],
+  "light_forest_green": [
+    79,
+    145,
+    83
+  ],
+  "light_gold": [
+    253,
+    220,
+    92
+  ],
+  "light_grass_green": [
+    154,
+    247,
+    100
+  ],
+  "light_green": [
+    150,
+    249,
+    123
+  ],
+  "light_green_blue": [
+    86,
+    252,
+    162
+  ],
+  "light_greenish_blue": [
+    99,
+    247,
+    180
+  ],
+  "light_grey": [
+    216,
+    220,
+    214
+  ],
+  "light_grey_blue": [
+    157,
+    188,
+    212
+  ],
+  "light_grey_green": [
+    183,
+    225,
+    161
+  ],
+  "light_indigo": [
+    109,
+    90,
+    207
+  ],
+  "light_khaki": [
+    230,
+    242,
+    162
+  ],
+  "light_lavendar": [
+    239,
+    192,
+    254
+  ],
+  "light_lavender": [
+    223,
+    197,
+    254
+  ],
+  "light_light_blue": [
+    202,
+    255,
+    251
+  ],
+  "light_light_green": [
+    200,
+    255,
+    176
+  ],
+  "light_lilac": [
+    237,
+    200,
+    255
+  ],
+  "light_lime": [
+    174,
+    253,
+    108
+  ],
+  "light_lime_green": [
+    185,
+    255,
+    102
+  ],
+  "light_magenta": [
+    250,
+    95,
+    247
+  ],
+  "light_maroon": [
+    162,
+    72,
+    87
+  ],
+  "light_mauve": [
+    194,
+    146,
+    161
+  ],
+  "light_mint": [
+    182,
+    255,
+    187
+  ],
+  "light_mint_green": [
+    166,
+    251,
+    178
+  ],
+  "light_moss_green": [
+    166,
+    200,
+    117
+  ],
+  "light_mustard": [
+    247,
+    213,
+    96
+  ],
+  "light_navy": [
+    21,
+    80,
+    132
+  ],
+  "light_navy_blue": [
+    46,
+    90,
+    136
+  ],
+  "light_neon_green": [
+    78,
+    253,
+    84
+  ],
+  "light_olive": [
+    172,
+    191,
+    105
+  ],
+  "light_olive_green": [
+    164,
+    190,
+    92
+  ],
+  "light_orange": [
+    253,
+    170,
+    72
+  ],
+  "light_pastel_green": [
+    178,
+    251,
+    165
+  ],
+  "light_pea_green": [
+    196,
+    254,
+    130
+  ],
+  "light_peach": [
+    255,
+    216,
+    177
+  ],
+  "light_periwinkle": [
+    193,
+    198,
+    252
+  ],
+  "light_pink": [
+    255,
+    209,
+    223
+  ],
+  "light_plum": [
+    157,
+    87,
+    131
+  ],
+  "light_purple": [
+    191,
+    119,
+    246
+  ],
+  "light_red": [
+    255,
+    71,
+    76
+  ],
+  "light_rose": [
+    255,
+    197,
+    203
+  ],
+  "light_royal_blue": [
+    58,
+    46,
+    254
+  ],
+  "light_sage": [
+    188,
+    236,
+    172
+  ],
+  "light_salmon": [
+    254,
+    169,
+    147
+  ],
+  "light_sea_green": [
+    152,
+    246,
+    176
+  ],
+  "light_seafoam": [
+    160,
+    254,
+    191
+  ],
+  "light_seafoam_green": [
+    167,
+    255,
+    181
+  ],
+  "light_sky_blue": [
+    198,
+    252,
+    255
+  ],
+  "light_tan": [
+    251,
+    238,
+    172
+  ],
+  "light_teal": [
+    144,
+    228,
+    193
+  ],
+  "light_turquoise": [
+    126,
+    244,
+    204
+  ],
+  "light_urple": [
+    179,
+    111,
+    246
+  ],
+  "light_violet": [
+    214,
+    180,
+    252
+  ],
+  "light_yellow": [
+    255,
+    254,
+    122
+  ],
+  "light_yellow_green": [
+    204,
+    253,
+    127
+  ],
+  "light_yellowish_green": [
+    194,
+    255,
+    137
+  ],
+  "lightblue": [
+    173,
+    216,
+    230
+  ],
+  "lightcoral": [
+    240,
+    128,
+    128
+  ],
+  "lightcyan": [
+    224,
+    255,
+    255
+  ],
+  "lighter_green": [
+    117,
+    253,
+    99
+  ],
+  "lighter_purple": [
+    165,
+    90,
+    244
+  ],
+  "lightgoldenrodyellow": [
+    250,
+    250,
+    210
+  ],
+  "lightgray": [
+    211,
+    211,
+    211
+  ],
+  "lightgreen": [
+    144,
+    238,
+    144
+  ],
+  "lightgrey": [
+    211,
+    211,
+    211
+  ],
+  "lightish_blue": [
+    61,
+    122,
+    253
+  ],
+  "lightish_green": [
+    97,
+    225,
+    96
+  ],
+  "lightish_purple": [
+    165,
+    82,
+    230
+  ],
+  "lightish_red": [
+    254,
+    47,
+    74
+  ],
+  "lightpink": [
+    255,
+    182,
+    193
+  ],
+  "lightsalmon": [
+    255,
+    160,
+    122
+  ],
+  "lightseagreen": [
+    32,
+    178,
+    170
+  ],
+  "lightskyblue": [
+    135,
+    206,
+    250
+  ],
+  "lightslategray": [
+    119,
+    136,
+    153
+  ],
+  "lightslategrey": [
+    119,
+    136,
+    153
+  ],
+  "lightsteelblue": [
+    176,
+    196,
+    222
+  ],
+  "lightyellow": [
+    255,
+    255,
+    224
+  ],
+  "lilac": [
+    206,
+    162,
+    253
+  ],
+  "liliac": [
+    196,
+    142,
+    253
+  ],
+  "lime": [
+    0,
+    255,
+    0
+  ],
+  "lime_green": [
+    137,
+    254,
+    5
+  ],
+  "lime_yellow": [
+    208,
+    254,
+    29
+  ],
+  "limegreen": [
+    50,
+    205,
+    50
+  ],
+  "linen": [
+    250,
+    240,
+    230
+  ],
+  "lipstick": [
+    213,
+    23,
+    78
+  ],
+  "lipstick_red": [
+    192,
+    2,
+    47
+  ],
+  "macaroni_and_cheese": [
+    239,
+    180,
+    53
+  ],
+  "magenta": [
+    255,
+    0,
+    255
+  ],
+  "mahogany": [
+    74,
+    1,
+    0
+  ],
+  "maize": [
+    244,
+    208,
+    84
+  ],
+  "mango": [
+    255,
+    166,
+    43
+  ],
+  "manilla": [
+    255,
+    250,
+    134
+  ],
+  "marigold": [
+    252,
+    192,
+    6
+  ],
+  "marine": [
+    4,
+    46,
+    96
+  ],
+  "marine_blue": [
+    1,
+    56,
+    106
+  ],
+  "maroon": [
+    128,
+    0,
+    0
+  ],
+  "mauve": [
+    174,
+    113,
+    129
+  ],
+  "medium_blue": [
+    44,
+    111,
+    187
+  ],
+  "medium_brown": [
+    127,
+    81,
+    18
+  ],
+  "medium_green": [
+    57,
+    173,
+    72
+  ],
+  "medium_grey": [
+    125,
+    127,
+    124
+  ],
+  "medium_pink": [
+    243,
+    97,
+    150
+  ],
+  "medium_purple": [
+    158,
+    67,
+    162
+  ],
+  "mediumaquamarine": [
+    102,
+    205,
+    170
+  ],
+  "mediumblue": [
+    0,
+    0,
+    205
+  ],
+  "mediumorchid": [
+    186,
+    85,
+    211
+  ],
+  "mediumpurple": [
+    147,
+    112,
+    219
+  ],
+  "mediumseagreen": [
+    60,
+    179,
+    113
+  ],
+  "mediumslateblue": [
+    123,
+    104,
+    238
+  ],
+  "mediumspringgreen": [
+    0,
+    250,
+    154
+  ],
+  "mediumturquoise": [
+    72,
+    209,
+    204
+  ],
+  "mediumvioletred": [
+    199,
+    21,
+    133
+  ],
+  "melon": [
+    255,
+    120,
+    85
+  ],
+  "merlot": [
+    115,
+    0,
+    57
+  ],
+  "metallic_blue": [
+    79,
+    115,
+    142
+  ],
+  "mid_blue": [
+    39,
+    106,
+    179
+  ],
+  "mid_green": [
+    80,
+    167,
+    71
+  ],
+  "midnight": [
+    3,
+    1,
+    45
+  ],
+  "midnight_blue": [
+    2,
+    0,
+    53
+  ],
+  "midnight_purple": [
+    40,
+    1,
+    55
+  ],
+  "midnightblue": [
+    25,
+    25,
+    112
+  ],
+  "military_green": [
+    102,
+    124,
+    62
+  ],
+  "milk_chocolate": [
+    127,
+    78,
+    30
+  ],
+  "mint": [
+    159,
+    254,
+    176
+  ],
+  "mint_green": [
+    143,
+    255,
+    159
+  ],
+  "mintcream": [
+    245,
+    255,
+    250
+  ],
+  "minty_green": [
+    11,
+    247,
+    125
+  ],
+  "mistyrose": [
+    255,
+    228,
+    225
+  ],
+  "moccasin": [
+    255,
+    228,
+    181
+  ],
+  "mocha": [
+    157,
+    118,
+    81
+  ],
+  "moss": [
+    118,
+    153,
+    88
+  ],
+  "moss_green": [
+    101,
+    139,
+    56
+  ],
+  "mossy_green": [
+    99,
+    139,
+    39
+  ],
+  "mud": [
+    115,
+    92,
+    18
+  ],
+  "mud_brown": [
+    96,
+    70,
+    15
+  ],
+  "mud_green": [
+    96,
+    102,
+    2
+  ],
+  "muddy_brown": [
+    136,
+    104,
+    6
+  ],
+  "muddy_green": [
+    101,
+    116,
+    50
+  ],
+  "muddy_yellow": [
+    191,
+    172,
+    5
+  ],
+  "mulberry": [
+    146,
+    10,
+    78
+  ],
+  "murky_green": [
+    108,
+    122,
+    14
+  ],
+  "mushroom": [
+    186,
+    158,
+    136
+  ],
+  "mustard": [
+    206,
+    179,
+    1
+  ],
+  "mustard_brown": [
+    172,
+    126,
+    4
+  ],
+  "mustard_green": [
+    168,
+    181,
+    4
+  ],
+  "mustard_yellow": [
+    210,
+    189,
+    10
+  ],
+  "muted_blue": [
+    59,
+    113,
+    159
+  ],
+  "muted_green": [
+    95,
+    160,
+    82
+  ],
+  "muted_pink": [
+    209,
+    118,
+    143
+  ],
+  "muted_purple": [
+    128,
+    91,
+    135
+  ],
+  "nasty_green": [
+    112,
+    178,
+    63
+  ],
+  "navajowhite": [
+    255,
+    222,
+    173
+  ],
+  "navy": [
+    0,
+    0,
+    128
+  ],
+  "navy_blue": [
+    0,
+    17,
+    70
+  ],
+  "navy_green": [
+    53,
+    83,
+    10
+  ],
+  "neon_blue": [
+    4,
+    217,
+    255
+  ],
+  "neon_green": [
+    12,
+    255,
+    12
+  ],
+  "neon_pink": [
+    254,
+    1,
+    154
+  ],
+  "neon_purple": [
+    188,
+    19,
+    254
+  ],
+  "neon_red": [
+    255,
+    7,
+    58
+  ],
+  "neon_yellow": [
+    207,
+    255,
+    4
+  ],
+  "nice_blue": [
+    16,
+    122,
+    176
+  ],
+  "night_blue": [
+    4,
+    3,
+    72
+  ],
+  "ocean": [
+    1,
+    123,
+    146
+  ],
+  "ocean_blue": [
+    3,
+    113,
+    156
+  ],
+  "ocean_green": [
+    61,
+    153,
+    115
+  ],
+  "ocher": [
+    191,
+    155,
+    12
+  ],
+  "ochre": [
+    191,
+    144,
+    5
+  ],
+  "ocre": [
+    198,
+    156,
+    4
+  ],
+  "off_blue": [
+    86,
+    132,
+    174
+  ],
+  "off_green": [
+    107,
+    163,
+    83
+  ],
+  "off_white": [
+    255,
+    255,
+    228
+  ],
+  "off_yellow": [
+    241,
+    243,
+    63
+  ],
+  "old_pink": [
+    199,
+    121,
+    134
+  ],
+  "old_rose": [
+    200,
+    127,
+    137
+  ],
+  "oldlace": [
+    253,
+    245,
+    230
+  ],
+  "olive": [
+    128,
+    128,
+    0
+  ],
+  "olive_brown": [
+    100,
+    84,
+    3
+  ],
+  "olive_drab": [
+    111,
+    118,
+    50
+  ],
+  "olive_green": [
+    103,
+    122,
+    4
+  ],
+  "olive_yellow": [
+    194,
+    183,
+    9
+  ],
+  "olivedrab": [
+    107,
+    142,
+    35
+  ],
+  "orange": [
+    255,
+    165,
+    0
+  ],
+  "orange_brown": [
+    190,
+    100,
+    0
+  ],
+  "orange_pink": [
+    255,
+    111,
+    82
+  ],
+  "orange_red": [
+    253,
+    65,
+    30
+  ],
+  "orange_yellow": [
+    255,
+    173,
+    1
+  ],
+  "orangeish": [
+    253,
+    141,
+    73
+  ],
+  "orangered": [
+    255,
+    69,
+    0
+  ],
+  "orangey_brown": [
+    177,
+    96,
+    2
+  ],
+  "orangey_red": [
+    250,
+    66,
+    36
+  ],
+  "orangey_yellow": [
+    253,
+    185,
+    21
+  ],
+  "orangish": [
+    252,
+    130,
+    74
+  ],
+  "orangish_brown": [
+    178,
+    95,
+    3
+  ],
+  "orangish_red": [
+    244,
+    54,
+    5
+  ],
+  "orchid": [
+    218,
+    112,
+    214
+  ],
+  "pale": [
+    255,
+    249,
+    208
+  ],
+  "pale_aqua": [
+    184,
+    255,
+    235
+  ],
+  "pale_blue": [
+    208,
+    254,
+    254
+  ],
+  "pale_brown": [
+    177,
+    145,
+    110
+  ],
+  "pale_cyan": [
+    183,
+    255,
+    250
+  ],
+  "pale_gold": [
+    253,
+    222,
+    108
+  ],
+  "pale_green": [
+    199,
+    253,
+    181
+  ],
+  "pale_grey": [
+    253,
+    253,
+    254
+  ],
+  "pale_lavender": [
+    238,
+    207,
+    254
+  ],
+  "pale_light_green": [
+    177,
+    252,
+    153
+  ],
+  "pale_lilac": [
+    228,
+    203,
+    255
+  ],
+  "pale_lime": [
+    190,
+    253,
+    115
+  ],
+  "pale_lime_green": [
+    177,
+    255,
+    101
+  ],
+  "pale_magenta": [
+    215,
+    103,
+    173
+  ],
+  "pale_mauve": [
+    254,
+    208,
+    252
+  ],
+  "pale_olive": [
+    185,
+    204,
+    129
+  ],
+  "pale_olive_green": [
+    177,
+    210,
+    123
+  ],
+  "pale_orange": [
+    255,
+    167,
+    86
+  ],
+  "pale_peach": [
+    255,
+    229,
+    173
+  ],
+  "pale_pink": [
+    255,
+    207,
+    220
+  ],
+  "pale_purple": [
+    183,
+    144,
+    212
+  ],
+  "pale_red": [
+    217,
+    84,
+    77
+  ],
+  "pale_rose": [
+    253,
+    193,
+    197
+  ],
+  "pale_salmon": [
+    255,
+    177,
+    154
+  ],
+  "pale_sky_blue": [
+    189,
+    246,
+    254
+  ],
+  "pale_teal": [
+    130,
+    203,
+    178
+  ],
+  "pale_turquoise": [
+    165,
+    251,
+    213
+  ],
+  "pale_violet": [
+    206,
+    174,
+    250
+  ],
+  "pale_yellow": [
+    255,
+    255,
+    132
+  ],
+  "palegoldenrod": [
+    238,
+    232,
+    170
+  ],
+  "palegreen": [
+    152,
+    251,
+    152
+  ],
+  "paleturquoise": [
+    175,
+    238,
+    238
+  ],
+  "palevioletred": [
+    219,
+    112,
+    147
+  ],
+  "papayawhip": [
+    255,
+    239,
+    213
+  ],
+  "parchment": [
+    254,
+    252,
+    175
+  ],
+  "pastel_blue": [
+    162,
+    191,
+    254
+  ],
+  "pastel_green": [
+    176,
+    255,
+    157
+  ],
+  "pastel_orange": [
+    255,
+    150,
+    79
+  ],
+  "pastel_pink": [
+    255,
+    186,
+    205
+  ],
+  "pastel_purple": [
+    202,
+    160,
+    255
+  ],
+  "pastel_red": [
+    219,
+    88,
+    86
+  ],
+  "pastel_yellow": [
+    255,
+    254,
+    113
+  ],
+  "pea": [
+    164,
+    191,
+    32
+  ],
+  "pea_green": [
+    142,
+    171,
+    18
+  ],
+  "pea_soup": [
+    146,
+    153,
+    1
+  ],
+  "pea_soup_green": [
+    148,
+    166,
+    23
+  ],
+  "peach": [
+    255,
+    176,
+    124
+  ],
+  "peachpuff": [
+    255,
+    218,
+    185
+  ],
+  "peachy_pink": [
+    255,
+    154,
+    138
+  ],
+  "peacock_blue": [
+    1,
+    103,
+    149
+  ],
+  "pear": [
+    203,
+    248,
+    95
+  ],
+  "periwinkle": [
+    142,
+    130,
+    254
+  ],
+  "periwinkle_blue": [
+    143,
+    153,
+    251
+  ],
+  "perrywinkle": [
+    143,
+    140,
+    231
+  ],
+  "peru": [
+    205,
+    133,
+    63
+  ],
+  "petrol": [
+    0,
+    95,
+    106
+  ],
+  "pig_pink": [
+    231,
+    142,
+    165
+  ],
+  "pine": [
+    43,
+    93,
+    52
+  ],
+  "pine_green": [
+    10,
+    72,
+    30
+  ],
+  "pink": [
+    255,
+    192,
+    203
+  ],
+  "pink/purple": [
+    239,
+    29,
+    231
+  ],
+  "pink_purple": [
+    219,
+    75,
+    218
+  ],
+  "pink_red": [
+    245,
+    5,
+    79
+  ],
+  "pinkish": [
+    212,
+    106,
+    126
+  ],
+  "pinkish_brown": [
+    177,
+    114,
+    97
+  ],
+  "pinkish_grey": [
+    200,
+    172,
+    169
+  ],
+  "pinkish_orange": [
+    255,
+    114,
+    76
+  ],
+  "pinkish_purple": [
+    214,
+    72,
+    215
+  ],
+  "pinkish_red": [
+    241,
+    12,
+    69
+  ],
+  "pinkish_tan": [
+    217,
+    155,
+    130
+  ],
+  "pinky": [
+    252,
+    134,
+    170
+  ],
+  "pinky_purple": [
+    201,
+    76,
+    190
+  ],
+  "pinky_red": [
+    252,
+    38,
+    71
+  ],
+  "piss_yellow": [
+    221,
+    214,
+    24
+  ],
+  "pistachio": [
+    192,
+    250,
+    139
+  ],
+  "plum": [
+    221,
+    160,
+    221
+  ],
+  "plum_purple": [
+    78,
+    5,
+    80
+  ],
+  "poison_green": [
+    64,
+    253,
+    20
+  ],
+  "poo": [
+    143,
+    115,
+    3
+  ],
+  "poo_brown": [
+    136,
+    95,
+    1
+  ],
+  "poop": [
+    127,
+    94,
+    0
+  ],
+  "poop_brown": [
+    122,
+    89,
+    1
+  ],
+  "poop_green": [
+    111,
+    124,
+    0
+  ],
+  "powder_blue": [
+    177,
+    209,
+    252
+  ],
+  "powder_pink": [
+    255,
+    178,
+    208
+  ],
+  "powderblue": [
+    176,
+    224,
+    230
+  ],
+  "primary_blue": [
+    8,
+    4,
+    249
+  ],
+  "prussian_blue": [
+    0,
+    69,
+    119
+  ],
+  "puce": [
+    165,
+    126,
+    82
+  ],
+  "puke": [
+    165,
+    165,
+    2
+  ],
+  "puke_brown": [
+    148,
+    119,
+    6
+  ],
+  "puke_green": [
+    154,
+    174,
+    7
+  ],
+  "puke_yellow": [
+    194,
+    190,
+    14
+  ],
+  "pumpkin": [
+    225,
+    119,
+    1
+  ],
+  "pumpkin_orange": [
+    251,
+    125,
+    7
+  ],
+  "pure_blue": [
+    2,
+    3,
+    226
+  ],
+  "purple": [
+    128,
+    0,
+    128
+  ],
+  "purple/blue": [
+    93,
+    33,
+    208
+  ],
+  "purple/pink": [
+    215,
+    37,
+    222
+  ],
+  "purple_blue": [
+    99,
+    45,
+    233
+  ],
+  "purple_brown": [
+    103,
+    58,
+    63
+  ],
+  "purple_grey": [
+    134,
+    111,
+    133
+  ],
+  "purple_pink": [
+    224,
+    63,
+    216
+  ],
+  "purple_red": [
+    153,
+    1,
+    71
+  ],
+  "purpleish": [
+    152,
+    86,
+    141
+  ],
+  "purpleish_blue": [
+    97,
+    64,
+    239
+  ],
+  "purpleish_pink": [
+    223,
+    78,
+    200
+  ],
+  "purpley": [
+    135,
+    86,
+    228
+  ],
+  "purpley_blue": [
+    95,
+    52,
+    231
+  ],
+  "purpley_grey": [
+    148,
+    126,
+    148
+  ],
+  "purpley_pink": [
+    200,
+    60,
+    185
+  ],
+  "purplish": [
+    148,
+    86,
+    140
+  ],
+  "purplish_blue": [
+    96,
+    30,
+    249
+  ],
+  "purplish_brown": [
+    107,
+    66,
+    71
+  ],
+  "purplish_grey": [
+    122,
+    104,
+    127
+  ],
+  "purplish_pink": [
+    206,
+    93,
+    174
+  ],
+  "purplish_red": [
+    176,
+    5,
+    75
+  ],
+  "purply": [
+    152,
+    63,
+    178
+  ],
+  "purply_blue": [
+    102,
+    26,
+    238
+  ],
+  "purply_pink": [
+    240,
+    117,
+    230
+  ],
+  "putty": [
+    190,
+    174,
+    138
+  ],
+  "racing_green": [
+    1,
+    70,
+    0
+  ],
+  "radioactive_green": [
+    44,
+    250,
+    31
+  ],
+  "raspberry": [
+    176,
+    1,
+    73
+  ],
+  "raw_sienna": [
+    154,
+    98,
+    0
+  ],
+  "raw_umber": [
+    167,
+    94,
+    9
+  ],
+  "really_light_blue": [
+    212,
+    255,
+    255
+  ],
+  "rebeccapurple": [
+    102,
+    51,
+    153
+  ],
+  "red": [
+    255,
+    0,
+    0
+  ],
+  "red_brown": [
+    139,
+    46,
+    22
+  ],
+  "red_orange": [
+    253,
+    60,
+    6
+  ],
+  "red_pink": [
+    250,
+    42,
+    85
+  ],
+  "red_purple": [
+    130,
+    7,
+    71
+  ],
+  "red_violet": [
+    158,
+    1,
+    104
+  ],
+  "red_wine": [
+    140,
+    0,
+    52
+  ],
+  "reddish": [
+    196,
+    66,
+    64
+  ],
+  "reddish_brown": [
+    127,
+    43,
+    10
+  ],
+  "reddish_grey": [
+    153,
+    117,
+    112
+  ],
+  "reddish_orange": [
+    248,
+    72,
+    28
+  ],
+  "reddish_pink": [
+    254,
+    44,
+    84
+  ],
+  "reddish_purple": [
+    145,
+    9,
+    81
+  ],
+  "reddy_brown": [
+    110,
+    16,
+    5
+  ],
+  "rich_blue": [
+    2,
+    27,
+    249
+  ],
+  "rich_purple": [
+    114,
+    0,
+    88
+  ],
+  "robin's_egg": [
+    109,
+    237,
+    253
+  ],
+  "robin's_egg_blue": [
+    152,
+    239,
+    249
+  ],
+  "robin_egg_blue": [
+    138,
+    241,
+    254
+  ],
+  "rosa": [
+    254,
+    134,
+    164
+  ],
+  "rose": [
+    207,
+    98,
+    117
+  ],
+  "rose_pink": [
+    247,
+    135,
+    154
+  ],
+  "rose_red": [
+    190,
+    1,
+    60
+  ],
+  "rosy_pink": [
+    246,
+    104,
+    142
+  ],
+  "rosybrown": [
+    188,
+    143,
+    143
+  ],
+  "rouge": [
+    171,
+    18,
+    57
+  ],
+  "royal": [
+    12,
+    23,
+    147
+  ],
+  "royal_blue": [
+    5,
+    4,
+    170
+  ],
+  "royal_purple": [
+    75,
+    0,
+    110
+  ],
+  "royalblue": [
+    65,
+    105,
+    225
+  ],
+  "ruby": [
+    202,
+    1,
+    71
+  ],
+  "russet": [
+    161,
+    57,
+    5
+  ],
+  "rust": [
+    168,
+    60,
+    9
+  ],
+  "rust_brown": [
+    139,
+    49,
+    3
+  ],
+  "rust_orange": [
+    196,
+    85,
+    8
+  ],
+  "rust_red": [
+    170,
+    39,
+    4
+  ],
+  "rusty_orange": [
+    205,
+    89,
+    9
+  ],
+  "rusty_red": [
+    175,
+    47,
+    13
+  ],
+  "saddlebrown": [
+    139,
+    69,
+    19
+  ],
+  "saffron": [
+    254,
+    178,
+    9
+  ],
+  "sage": [
+    135,
+    174,
+    115
+  ],
+  "sage_green": [
+    136,
+    179,
+    120
+  ],
+  "salmon": [
+    250,
+    128,
+    114
+  ],
+  "salmon_pink": [
+    254,
+    123,
+    124
+  ],
+  "sand": [
+    226,
+    202,
+    118
+  ],
+  "sand_brown": [
+    203,
+    165,
+    96
+  ],
+  "sand_yellow": [
+    252,
+    225,
+    102
+  ],
+  "sandstone": [
+    201,
+    174,
+    116
+  ],
+  "sandy": [
+    241,
+    218,
+    122
+  ],
+  "sandy_brown": [
+    196,
+    166,
+    97
+  ],
+  "sandy_yellow": [
+    253,
+    238,
+    115
+  ],
+  "sandybrown": [
+    244,
+    164,
+    96
+  ],
+  "sap_green": [
+    92,
+    139,
+    21
+  ],
+  "sapphire": [
+    33,
+    56,
+    171
+  ],
+  "scarlet": [
+    190,
+    1,
+    25
+  ],
+  "sea": [
+    60,
+    153,
+    146
+  ],
+  "sea_blue": [
+    4,
+    116,
+    149
+  ],
+  "sea_green": [
+    83,
+    252,
+    161
+  ],
+  "seafoam": [
+    128,
+    249,
+    173
+  ],
+  "seafoam_blue": [
+    120,
+    209,
+    182
+  ],
+  "seafoam_green": [
+    122,
+    249,
+    171
+  ],
+  "seagreen": [
+    46,
+    139,
+    87
+  ],
+  "seashell": [
+    255,
+    245,
+    238
+  ],
+  "seaweed": [
+    24,
+    209,
+    123
+  ],
+  "seaweed_green": [
+    53,
+    173,
+    107
+  ],
+  "sepia": [
+    152,
+    94,
+    43
+  ],
+  "shamrock": [
+    1,
+    180,
+    76
+  ],
+  "shamrock_green": [
+    2,
+    193,
+    77
+  ],
+  "shit": [
+    127,
+    95,
+    0
+  ],
+  "shit_brown": [
+    123,
+    88,
+    4
+  ],
+  "shit_green": [
+    117,
+    128,
+    0
+  ],
+  "shocking_pink": [
+    254,
+    2,
+    162
+  ],
+  "sick_green": [
+    157,
+    185,
+    44
+  ],
+  "sickly_green": [
+    148,
+    178,
+    28
+  ],
+  "sickly_yellow": [
+    208,
+    228,
+    41
+  ],
+  "sienna": [
+    160,
+    82,
+    45
+  ],
+  "silver": [
+    192,
+    192,
+    192
+  ],
+  "sky": [
+    130,
+    202,
+    252
+  ],
+  "sky_blue": [
+    117,
+    187,
+    253
+  ],
+  "skyblue": [
+    135,
+    206,
+    235
+  ],
+  "slate": [
+    81,
+    101,
+    114
+  ],
+  "slate_blue": [
+    91,
+    124,
+    153
+  ],
+  "slate_green": [
+    101,
+    141,
+    109
+  ],
+  "slate_grey": [
+    89,
+    101,
+    109
+  ],
+  "slateblue": [
+    106,
+    90,
+    205
+  ],
+  "slategray": [
+    112,
+    128,
+    144
+  ],
+  "slategrey": [
+    112,
+    128,
+    144
+  ],
+  "slime_green": [
+    153,
+    204,
+    4
+  ],
+  "snot": [
+    172,
+    187,
+    13
+  ],
+  "snot_green": [
+    157,
+    193,
+    0
+  ],
+  "snow": [
+    255,
+    250,
+    250
+  ],
+  "soft_blue": [
+    100,
+    136,
+    234
+  ],
+  "soft_green": [
+    111,
+    194,
+    118
+  ],
+  "soft_pink": [
+    253,
+    176,
+    192
+  ],
+  "soft_purple": [
+    166,
+    111,
+    181
+  ],
+  "spearmint": [
+    30,
+    248,
+    118
+  ],
+  "spring_green": [
+    169,
+    249,
+    113
+  ],
+  "springgreen": [
+    0,
+    255,
+    127
+  ],
+  "spruce": [
+    10,
+    95,
+    56
+  ],
+  "squash": [
+    242,
+    171,
+    21
+  ],
+  "steel": [
+    115,
+    133,
+    149
+  ],
+  "steel_blue": [
+    90,
+    125,
+    154
+  ],
+  "steel_grey": [
+    111,
+    130,
+    138
+  ],
+  "steelblue": [
+    70,
+    130,
+    180
+  ],
+  "stone": [
+    173,
+    165,
+    135
+  ],
+  "stormy_blue": [
+    80,
+    123,
+    156
+  ],
+  "straw": [
+    252,
+    246,
+    121
+  ],
+  "strawberry": [
+    251,
+    41,
+    67
+  ],
+  "strong_blue": [
+    12,
+    6,
+    247
+  ],
+  "strong_pink": [
+    255,
+    7,
+    137
+  ],
+  "sun_yellow": [
+    255,
+    223,
+    34
+  ],
+  "sunflower": [
+    255,
+    197,
+    18
+  ],
+  "sunflower_yellow": [
+    255,
+    218,
+    3
+  ],
+  "sunny_yellow": [
+    255,
+    249,
+    23
+  ],
+  "sunshine_yellow": [
+    255,
+    253,
+    55
+  ],
+  "swamp": [
+    105,
+    131,
+    57
+  ],
+  "swamp_green": [
+    116,
+    133,
+    0
+  ],
+  "tan": [
+    210,
+    180,
+    140
+  ],
+  "tan_brown": [
+    171,
+    126,
+    76
+  ],
+  "tan_green": [
+    169,
+    190,
+    112
+  ],
+  "tangerine": [
+    255,
+    148,
+    8
+  ],
+  "taupe": [
+    185,
+    162,
+    129
+  ],
+  "tea": [
+    101,
+    171,
+    124
+  ],
+  "tea_green": [
+    189,
+    248,
+    163
+  ],
+  "teal": [
+    0,
+    128,
+    128
+  ],
+  "teal_blue": [
+    1,
+    136,
+    159
+  ],
+  "teal_green": [
+    37,
+    163,
+    111
+  ],
+  "tealish": [
+    36,
+    188,
+    168
+  ],
+  "tealish_green": [
+    12,
+    220,
+    115
+  ],
+  "terra_cotta": [
+    201,
+    100,
+    59
+  ],
+  "terracota": [
+    203,
+    104,
+    67
+  ],
+  "terracotta": [
+    202,
+    102,
+    65
+  ],
+  "thistle": [
+    216,
+    191,
+    216
+  ],
+  "tiffany_blue": [
+    123,
+    242,
+    218
+  ],
+  "tomato": [
+    255,
+    99,
+    71
+  ],
+  "tomato_red": [
+    236,
+    45,
+    1
+  ],
+  "topaz": [
+    19,
+    187,
+    175
+  ],
+  "toupe": [
+    199,
+    172,
+    125
+  ],
+  "toxic_green": [
+    97,
+    222,
+    42
+  ],
+  "tree_green": [
+    42,
+    126,
+    25
+  ],
+  "true_blue": [
+    1,
+    15,
+    204
+  ],
+  "true_green": [
+    8,
+    148,
+    4
+  ],
+  "turquoise": [
+    64,
+    224,
+    208
+  ],
+  "turquoise_blue": [
+    6,
+    177,
+    196
+  ],
+  "turquoise_green": [
+    4,
+    244,
+    137
+  ],
+  "turtle_green": [
+    117,
+    184,
+    79
+  ],
+  "twilight": [
+    78,
+    81,
+    139
+  ],
+  "twilight_blue": [
+    10,
+    67,
+    122
+  ],
+  "ugly_blue": [
+    49,
+    102,
+    138
+  ],
+  "ugly_brown": [
+    125,
+    113,
+    3
+  ],
+  "ugly_green": [
+    122,
+    151,
+    3
+  ],
+  "ugly_pink": [
+    205,
+    117,
+    132
+  ],
+  "ugly_purple": [
+    164,
+    66,
+    160
+  ],
+  "ugly_yellow": [
+    208,
+    193,
+    1
+  ],
+  "ultramarine": [
+    32,
+    0,
+    177
+  ],
+  "ultramarine_blue": [
+    24,
+    5,
+    219
+  ],
+  "umber": [
+    178,
+    100,
+    0
+  ],
+  "velvet": [
+    117,
+    8,
+    81
+  ],
+  "vermillion": [
+    244,
+    50,
+    12
+  ],
+  "very_dark_blue": [
+    0,
+    1,
+    51
+  ],
+  "very_dark_brown": [
+    29,
+    2,
+    0
+  ],
+  "very_dark_green": [
+    6,
+    46,
+    3
+  ],
+  "very_dark_purple": [
+    42,
+    1,
+    52
+  ],
+  "very_light_blue": [
+    213,
+    255,
+    255
+  ],
+  "very_light_brown": [
+    211,
+    182,
+    131
+  ],
+  "very_light_green": [
+    209,
+    255,
+    189
+  ],
+  "very_light_pink": [
+    255,
+    244,
+    242
+  ],
+  "very_light_purple": [
+    246,
+    206,
+    252
+  ],
+  "very_pale_blue": [
+    214,
+    255,
+    254
+  ],
+  "very_pale_green": [
+    207,
+    253,
+    188
+  ],
+  "vibrant_blue": [
+    3,
+    57,
+    248
+  ],
+  "vibrant_green": [
+    10,
+    221,
+    8
+  ],
+  "vibrant_purple": [
+    173,
+    3,
+    222
+  ],
+  "violet": [
+    238,
+    130,
+    238
+  ],
+  "violet_blue": [
+    81,
+    10,
+    201
+  ],
+  "violet_pink": [
+    251,
+    95,
+    252
+  ],
+  "violet_red": [
+    165,
+    0,
+    85
+  ],
+  "viridian": [
+    30,
+    145,
+    103
+  ],
+  "vivid_blue": [
+    21,
+    46,
+    255
+  ],
+  "vivid_green": [
+    47,
+    239,
+    16
+  ],
+  "vivid_purple": [
+    153,
+    0,
+    250
+  ],
+  "vomit": [
+    162,
+    164,
+    21
+  ],
+  "vomit_green": [
+    137,
+    162,
+    3
+  ],
+  "vomit_yellow": [
+    199,
+    193,
+    12
+  ],
+  "warm_blue": [
+    75,
+    87,
+    219
+  ],
+  "warm_brown": [
+    150,
+    78,
+    2
+  ],
+  "warm_grey": [
+    151,
+    138,
+    132
+  ],
+  "warm_pink": [
+    251,
+    85,
+    129
+  ],
+  "warm_purple": [
+    149,
+    46,
+    143
+  ],
+  "warm_white": [
+    255,
+    165,
+    0
+  ],
+  "washed_out_green": [
+    188,
+    245,
+    166
+  ],
+  "water_blue": [
+    14,
+    135,
+    204
+  ],
+  "watermelon": [
+    253,
+    70,
+    89
+  ],
+  "weird_green": [
+    58,
+    229,
+    127
+  ],
+  "wheat": [
+    245,
+    222,
+    179
+  ],
+  "white": [
+    255,
+    255,
+    255
+  ],
+  "whitesmoke": [
+    245,
+    245,
+    245
+  ],
+  "windows_blue": [
+    55,
+    120,
+    191
+  ],
+  "wine": [
+    128,
+    1,
+    63
+  ],
+  "wine_red": [
+    123,
+    3,
+    35
+  ],
+  "wintergreen": [
+    32,
+    249,
+    134
+  ],
+  "wisteria": [
+    168,
+    125,
+    194
+  ],
+  "yellow": [
+    255,
+    255,
+    0
+  ],
+  "yellow/green": [
+    200,
+    253,
+    61
+  ],
+  "yellow_brown": [
+    183,
+    148,
+    0
+  ],
+  "yellow_green": [
+    192,
+    251,
+    45
+  ],
+  "yellow_ochre": [
+    203,
+    157,
+    6
+  ],
+  "yellow_orange": [
+    252,
+    176,
+    1
+  ],
+  "yellow_tan": [
+    255,
+    227,
+    110
+  ],
+  "yellowgreen": [
+    154,
+    205,
+    50
+  ],
+  "yellowish": [
+    250,
+    238,
+    102
+  ],
+  "yellowish_brown": [
+    155,
+    122,
+    1
+  ],
+  "yellowish_green": [
+    176,
+    221,
+    22
+  ],
+  "yellowish_orange": [
+    255,
+    171,
+    15
+  ],
+  "yellowish_tan": [
+    252,
+    252,
+    129
+  ],
+  "yellowy_brown": [
+    174,
+    139,
+    12
+  ],
+  "yellowy_green": [
+    191,
+    241,
+    40
+  ]
+}

--- a/packages/ha_lib/inference.py
+++ b/packages/ha_lib/inference.py
@@ -1,0 +1,57 @@
+"""Infer the HA service (action) to call for a given domain + user-supplied params.
+
+Used by the quick-exec flow where the user types
+``<entity_id> <param_str>`` and expects the workflow to figure out the
+right service (e.g. ``light.turn_on`` when they supply brightness/color).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from ha_lib.entities import ACTION_PARAMS, get_domain_config
+
+
+def infer_action(domain: str, param_keys: Iterable[str]) -> str:
+    """Pick the best-matching action in *domain* for the supplied *param_keys*.
+
+    Rules:
+
+    1. No params supplied → the domain's default action
+       (e.g. ``light`` → ``toggle``).
+    2. Else, score every parameterized action registered for *domain* by
+       the number of user-supplied keys it declares.  The strict winner is
+       returned.
+    3. On a tie (or when nothing matches), fall back to the default action.
+    4. Unknown domain with no default → ``""``.
+
+    The returned string is always safe to pass to ``dispatch_action`` — it's
+    either a valid action for the domain or an empty string that the
+    dispatcher will reject with a clear error.
+    """
+    keys = {k for k in param_keys if k}
+    default = get_domain_config(domain).default_action
+
+    if not keys:
+        return default
+
+    candidates = [
+        (action, set(p.name for p in params))
+        for (dom, action), params in ACTION_PARAMS.items()
+        if dom == domain
+    ]
+    if not candidates:
+        return default
+
+    scored = [(len(keys & declared), action) for action, declared in candidates]
+    scored.sort(key=lambda t: (-t[0], t[1]))  # highest score, then alpha for stability
+
+    top_score = scored[0][0]
+    if top_score == 0:
+        return default
+    # Strict winner only — avoid guessing on ties (e.g. cover.open_cover vs
+    # cover.close_cover both take ``position``).
+    if len(scored) > 1 and scored[1][0] == top_score:
+        return default
+
+    return scored[0][1]

--- a/packages/ha_lib/params.py
+++ b/packages/ha_lib/params.py
@@ -5,10 +5,49 @@ from __future__ import annotations
 import math
 from typing import Optional, Union
 
+from ha_lib.colors import resolve_color
 from ha_lib.entities import get_action_params
+
+# Short aliases users can type; the canonical HA service_data key on the right.
+_KEY_ALIASES: dict[str, str] = {
+    "color": "color_name",
+}
 
 # Type produced by the parser — values are coerced to their declared types.
 ParamValue = Union[int, float, str, bool]
+
+
+def extract_param_keys(raw: str) -> list[str]:
+    """Return the canonical key names the user supplied in *raw*.
+
+    Aliases are resolved (``color`` → ``color_name``) and the ``rgb_color``
+    triplet is detected specially.  Used by the quick-exec flow to pick the
+    right action before full parsing; safe to call on partially-typed input.
+    """
+    if not raw or not raw.strip():
+        return []
+    keys: list[str] = []
+    remaining = raw
+    if "rgb_color:" in remaining:
+        keys.append("rgb_color")
+        # Scrub the rgb_color portion so we don't mis-read its numeric triplet
+        # as further key:value pairs.
+        before, rgb_rest = remaining.split("rgb_color:", 1)
+        try:
+            _, after = _extract_rgb(rgb_rest)
+        except ValueError:
+            after = ""
+        parts = [p.strip() for p in [before.rstrip(",").strip(), after] if p.strip()]
+        remaining = ",".join(parts)
+    for pair in remaining.split(","):
+        pair = pair.strip()
+        if ":" not in pair:
+            continue
+        key, _ = pair.split(":", 1)
+        key = _KEY_ALIASES.get(key.strip(), key.strip())
+        if key:
+            keys.append(key)
+    return keys
 
 
 def parse_service_params(
@@ -27,6 +66,9 @@ def parse_service_params(
     * **brightness** — a trailing ``%`` converts the percentage (0-100) to the
       HA 0-255 range.
     * **rgb_color** — ``"255,0,0"`` is converted to ``[255, 0, 0]``.
+    * **color / color_name** — a known named color (``red``, ``eggshell``,
+      ``warm_white``, etc.) is resolved to ``rgb_color`` so HA gets coordinates
+      it always understands.  Unknown names pass through as ``color_name``.
 
     Raises :class:`ValueError` on parse or validation failures.
     """
@@ -60,6 +102,17 @@ def parse_service_params(
         value = value.strip()
         if not key:
             raise ValueError(f"Empty parameter name in: {pair!r}")
+
+        key = _KEY_ALIASES.get(key, key)
+
+        # Color-name resolution: turn known names into rgb_color so HA
+        # receives a palette-independent coordinate.
+        if key == "color_name":
+            rgb = resolve_color(value)
+            if rgb is not None:
+                result["rgb_color"] = [rgb[0], rgb[1], rgb[2]]
+                continue
+            # Unknown name — fall through and let HA try color_name.
 
         param_def = param_defs.get(key)
         if param_def is None:

--- a/packages/ha_lib/query_parser.py
+++ b/packages/ha_lib/query_parser.py
@@ -13,6 +13,10 @@ from ha_lib.entities import DOMAIN_REGISTRY
 # ---------------------------------------------------------------------------
 
 _DOMAIN_PREFIX_RE = re.compile(r"^([a-z_]+):(.*)$")
+# Entity IDs are ``<domain>.<object_id>`` where both sides are lowercase
+# identifiers / digits / underscores.  We require a ``.`` and a known domain
+# so quick-exec only fires on well-formed entity references.
+_ENTITY_ID_RE = re.compile(r"^([a-z_]+)\.([a-z0-9_]+)$")
 
 
 @dataclass(frozen=True)
@@ -23,19 +27,28 @@ class ParsedQuery:
     ----------
     mode:
         ``"fuzzy"`` for standard fuzzy search, ``"regex"`` for regex matching,
-        or ``"domain_browse"`` when a domain filter is given with no text.
+        ``"domain_browse"`` when a domain filter is given with no text, or
+        ``"quick_exec"`` when the input is an entity_id optionally followed
+        by a parameter string (e.g. ``light.foo brightness:80,color:red``).
     text:
         The search text after extracting modifiers.
     domain_filter:
         Domain name to restrict results (e.g. ``"light"``), or ``None``.
     regex_pattern:
         Regex pattern string extracted from ``/pattern/`` syntax, or ``None``.
+    entity_id:
+        For ``quick_exec`` mode — the fully-qualified entity ID.
+    raw_params:
+        For ``quick_exec`` mode — the raw comma-separated param string
+        (may be empty, meaning "fire the default action with no params").
     """
 
-    mode: str  # "fuzzy" | "regex" | "domain_browse"
+    mode: str  # "fuzzy" | "regex" | "domain_browse" | "quick_exec"
     text: str
     domain_filter: Optional[str]
     regex_pattern: Optional[str]
+    entity_id: Optional[str] = None
+    raw_params: Optional[str] = None
 
 
 # ---------------------------------------------------------------------------
@@ -46,11 +59,17 @@ class ParsedQuery:
 def parse_query(raw: str) -> ParsedQuery:
     """Parse *raw* query text into a :class:`ParsedQuery`.
 
-    Supports three syntaxes:
+    Supports four syntaxes:
 
     1. ``/pattern/`` — regex search
-    2. ``domain:text`` — domain-filtered fuzzy search (or browse if *text* empty)
-    3. Plain text — standard fuzzy search
+    2. ``<domain>.<object_id> [params]`` — quick-exec (needs a known domain
+       and, at call time, an entity that actually exists in the cache)
+    3. ``domain:text`` — domain-filtered fuzzy search (or browse if *text* empty)
+    4. Plain text — standard fuzzy search
+
+    Quick-exec detection here only validates *shape* — whether the entity
+    exists in the cache is the caller's responsibility, so typos cleanly
+    fall back to fuzzy search.
     """
     stripped = raw.strip()
 
@@ -64,7 +83,22 @@ def parse_query(raw: str) -> ParsedQuery:
             regex_pattern=pattern,
         )
 
-    # 2. Domain filter syntax: domain:text
+    # 2. Quick-exec: <entity_id> [params]
+    #    First whitespace-separated token is a well-formed entity_id on a
+    #    known domain; the rest is the raw param string.
+    first, _, rest = stripped.partition(" ")
+    em = _ENTITY_ID_RE.match(first)
+    if em and em.group(1) in DOMAIN_REGISTRY:
+        return ParsedQuery(
+            mode="quick_exec",
+            text="",
+            domain_filter=None,
+            regex_pattern=None,
+            entity_id=first,
+            raw_params=rest.strip(),
+        )
+
+    # 3. Domain filter syntax: domain:text
     m = _DOMAIN_PREFIX_RE.match(stripped)
     if m:
         candidate_domain = m.group(1)
@@ -85,7 +119,7 @@ def parse_query(raw: str) -> ParsedQuery:
             )
         # Invalid domain prefix — fall through to plain fuzzy search
 
-    # 3. Plain fuzzy search
+    # 4. Plain fuzzy search
     return ParsedQuery(
         mode="fuzzy",
         text=stripped,

--- a/scripts/build_colors.py
+++ b/scripts/build_colors.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""One-off builder for packages/ha_lib/data/colors.json.
+
+Combines:
+
+* XKCD color survey names (CC0) — ~950 names from https://xkcd.com/color/rgb.txt
+* CSS4 / X11 standard color names (public domain)
+* Home Assistant ``light.color_name`` extras (``warm_white``, ``cool_white``,
+  ``homeassistant_orange``, etc.) so HA-specific names resolve too.
+
+Run this once when updating the palette::
+
+    python3 scripts/build_colors.py
+
+Output: ``packages/ha_lib/data/colors.json`` — a sorted ``{name: [r, g, b]}``
+map with ``_``-joined lowercase keys.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.request
+
+_XKCD_URL = "https://xkcd.com/color/rgb.txt"
+
+# CSS4 / X11 standard colors (public domain). Mirrors matplotlib's CSS4_COLORS
+# but bundled here so we have zero runtime dependencies.
+_CSS4: dict[str, str] = {
+    "aliceblue": "#f0f8ff",
+    "antiquewhite": "#faebd7",
+    "aqua": "#00ffff",
+    "aquamarine": "#7fffd4",
+    "azure": "#f0ffff",
+    "beige": "#f5f5dc",
+    "bisque": "#ffe4c4",
+    "black": "#000000",
+    "blanchedalmond": "#ffebcd",
+    "blue": "#0000ff",
+    "blueviolet": "#8a2be2",
+    "brown": "#a52a2a",
+    "burlywood": "#deb887",
+    "cadetblue": "#5f9ea0",
+    "chartreuse": "#7fff00",
+    "chocolate": "#d2691e",
+    "coral": "#ff7f50",
+    "cornflowerblue": "#6495ed",
+    "cornsilk": "#fff8dc",
+    "crimson": "#dc143c",
+    "cyan": "#00ffff",
+    "darkblue": "#00008b",
+    "darkcyan": "#008b8b",
+    "darkgoldenrod": "#b8860b",
+    "darkgray": "#a9a9a9",
+    "darkgreen": "#006400",
+    "darkgrey": "#a9a9a9",
+    "darkkhaki": "#bdb76b",
+    "darkmagenta": "#8b008b",
+    "darkolivegreen": "#556b2f",
+    "darkorange": "#ff8c00",
+    "darkorchid": "#9932cc",
+    "darkred": "#8b0000",
+    "darksalmon": "#e9967a",
+    "darkseagreen": "#8fbc8f",
+    "darkslateblue": "#483d8b",
+    "darkslategray": "#2f4f4f",
+    "darkslategrey": "#2f4f4f",
+    "darkturquoise": "#00ced1",
+    "darkviolet": "#9400d3",
+    "deeppink": "#ff1493",
+    "deepskyblue": "#00bfff",
+    "dimgray": "#696969",
+    "dimgrey": "#696969",
+    "dodgerblue": "#1e90ff",
+    "firebrick": "#b22222",
+    "floralwhite": "#fffaf0",
+    "forestgreen": "#228b22",
+    "fuchsia": "#ff00ff",
+    "gainsboro": "#dcdcdc",
+    "ghostwhite": "#f8f8ff",
+    "gold": "#ffd700",
+    "goldenrod": "#daa520",
+    "gray": "#808080",
+    "green": "#008000",
+    "greenyellow": "#adff2f",
+    "grey": "#808080",
+    "honeydew": "#f0fff0",
+    "hotpink": "#ff69b4",
+    "indianred": "#cd5c5c",
+    "indigo": "#4b0082",
+    "ivory": "#fffff0",
+    "khaki": "#f0e68c",
+    "lavender": "#e6e6fa",
+    "lavenderblush": "#fff0f5",
+    "lawngreen": "#7cfc00",
+    "lemonchiffon": "#fffacd",
+    "lightblue": "#add8e6",
+    "lightcoral": "#f08080",
+    "lightcyan": "#e0ffff",
+    "lightgoldenrodyellow": "#fafad2",
+    "lightgray": "#d3d3d3",
+    "lightgreen": "#90ee90",
+    "lightgrey": "#d3d3d3",
+    "lightpink": "#ffb6c1",
+    "lightsalmon": "#ffa07a",
+    "lightseagreen": "#20b2aa",
+    "lightskyblue": "#87cefa",
+    "lightslategray": "#778899",
+    "lightslategrey": "#778899",
+    "lightsteelblue": "#b0c4de",
+    "lightyellow": "#ffffe0",
+    "lime": "#00ff00",
+    "limegreen": "#32cd32",
+    "linen": "#faf0e6",
+    "magenta": "#ff00ff",
+    "maroon": "#800000",
+    "mediumaquamarine": "#66cdaa",
+    "mediumblue": "#0000cd",
+    "mediumorchid": "#ba55d3",
+    "mediumpurple": "#9370db",
+    "mediumseagreen": "#3cb371",
+    "mediumslateblue": "#7b68ee",
+    "mediumspringgreen": "#00fa9a",
+    "mediumturquoise": "#48d1cc",
+    "mediumvioletred": "#c71585",
+    "midnightblue": "#191970",
+    "mintcream": "#f5fffa",
+    "mistyrose": "#ffe4e1",
+    "moccasin": "#ffe4b5",
+    "navajowhite": "#ffdead",
+    "navy": "#000080",
+    "oldlace": "#fdf5e6",
+    "olive": "#808000",
+    "olivedrab": "#6b8e23",
+    "orange": "#ffa500",
+    "orangered": "#ff4500",
+    "orchid": "#da70d6",
+    "palegoldenrod": "#eee8aa",
+    "palegreen": "#98fb98",
+    "paleturquoise": "#afeeee",
+    "palevioletred": "#db7093",
+    "papayawhip": "#ffefd5",
+    "peachpuff": "#ffdab9",
+    "peru": "#cd853f",
+    "pink": "#ffc0cb",
+    "plum": "#dda0dd",
+    "powderblue": "#b0e0e6",
+    "purple": "#800080",
+    "rebeccapurple": "#663399",
+    "red": "#ff0000",
+    "rosybrown": "#bc8f8f",
+    "royalblue": "#4169e1",
+    "saddlebrown": "#8b4513",
+    "salmon": "#fa8072",
+    "sandybrown": "#f4a460",
+    "seagreen": "#2e8b57",
+    "seashell": "#fff5ee",
+    "sienna": "#a0522d",
+    "silver": "#c0c0c0",
+    "skyblue": "#87ceeb",
+    "slateblue": "#6a5acd",
+    "slategray": "#708090",
+    "slategrey": "#708090",
+    "snow": "#fffafa",
+    "springgreen": "#00ff7f",
+    "steelblue": "#4682b4",
+    "tan": "#d2b48c",
+    "teal": "#008080",
+    "thistle": "#d8bfd8",
+    "tomato": "#ff6347",
+    "turquoise": "#40e0d0",
+    "violet": "#ee82ee",
+    "wheat": "#f5deb3",
+    "white": "#ffffff",
+    "whitesmoke": "#f5f5f5",
+    "yellow": "#ffff00",
+    "yellowgreen": "#9acd32",
+}
+
+# Home Assistant ``light.color_name`` extras beyond CSS4.
+_HA_EXTRAS: dict[str, str] = {
+    "warm_white": "#ffa500",
+    "cool_white": "#f5f5f5",
+    "homeassistant_orange": "#18bcf2",
+    "homeassistant_blue": "#18bcf2",
+}
+
+
+def _normalize(name: str) -> str:
+    return name.strip().lower().replace(" ", "_")
+
+
+def _hex_to_rgb(h: str) -> list[int]:
+    h = h.strip().lstrip("#")
+    if len(h) != 6:
+        raise ValueError(f"Bad hex: {h!r}")
+    return [int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16)]
+
+
+def main() -> int:
+    print(f"Fetching {_XKCD_URL}...", file=sys.stderr)
+    with urllib.request.urlopen(_XKCD_URL, timeout=30) as resp:
+        body = resp.read().decode("utf-8")
+
+    palette: dict[str, list[int]] = {}
+
+    # Precedence matters: XKCD first for breadth (~950 names), then CSS4
+    # overrides on collision so basics (``red`` → 255,0,0) match what users
+    # expect from web colors rather than XKCD's slightly off-spec values
+    # (``red`` → 229,0,0).  HA extras win last.
+    xkcd_count = 0
+    for line in body.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        parts = line.split("\t")
+        if len(parts) < 2:
+            continue
+        name = _normalize(parts[0])
+        if not name:
+            continue
+        try:
+            palette[name] = _hex_to_rgb(parts[1])
+            xkcd_count += 1
+        except ValueError:
+            continue
+
+    for name, hex_val in _CSS4.items():
+        palette[_normalize(name)] = _hex_to_rgb(hex_val)
+
+    for name, hex_val in _HA_EXTRAS.items():
+        palette[_normalize(name)] = _hex_to_rgb(hex_val)
+
+    out_path = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+        "packages",
+        "ha_lib",
+        "data",
+        "colors.json",
+    )
+    os.makedirs(os.path.dirname(out_path), exist_ok=True)
+
+    sorted_palette = dict(sorted(palette.items()))
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump(sorted_palette, f, indent=2, sort_keys=True)
+        f.write("\n")
+
+    print(
+        f"Wrote {len(sorted_palette)} colors to {out_path} "
+        f"(CSS4: {len(_CSS4)}, HA extras: {len(_HA_EXTRAS)}, XKCD: {xkcd_count})",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/ha_workflow/cache.py
+++ b/src/ha_workflow/cache.py
@@ -108,6 +108,17 @@ class EntityCache:
         )
         return [self._row_to_entity(row) for row in cur.fetchall()]
 
+    def get_by_entity_id(self, entity_id: str) -> Optional[Entity]:
+        """Return the cached entity with *entity_id*, or ``None`` if missing."""
+        cur = self._conn.execute(
+            "SELECT entity_id, domain, state, friendly_name, "
+            "attributes_json, last_changed, last_updated, area_name, device_id "
+            "FROM entities WHERE entity_id = ?",
+            (entity_id,),
+        )
+        row = cur.fetchone()
+        return self._row_to_entity(row) if row else None
+
     def get_by_domain(self, domain: str) -> list[Entity]:
         """Return all cached entities in the given *domain*."""
         cur = self._conn.execute(

--- a/src/ha_workflow/colors.py
+++ b/src/ha_workflow/colors.py
@@ -1,0 +1,46 @@
+"""Named-color resolution.
+
+Maps human-friendly color names (CSS4 + X11 + XKCD + HA extras) to RGB
+triplets.  The bundled JSON is built by ``scripts/build_colors.py`` and
+shared with the ha_lib package at ``packages/ha_lib/data/colors.json``.
+
+Resolution is permissive: names are lowercased and spaces, dashes, and
+underscores are all treated as the same separator, so ``"warm white"``,
+``"warm-white"``, and ``"warm_white"`` all resolve to the same color.
+"""
+
+from __future__ import annotations
+
+import json
+from functools import lru_cache
+from pathlib import Path
+from typing import Optional
+
+# The canonical palette lives under packages/ha_lib/data/colors.json.
+# The repo has packages/ as a sibling of src/, so resolve relative to the
+# parent of src/ha_workflow/.
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_DATA_PATH = _REPO_ROOT / "packages" / "ha_lib" / "data" / "colors.json"
+
+
+def _normalize(name: str) -> str:
+    return name.strip().lower().replace("-", "_").replace(" ", "_")
+
+
+@lru_cache(maxsize=1)
+def _palette() -> dict[str, tuple[int, int, int]]:
+    with _DATA_PATH.open("r", encoding="utf-8") as f:
+        raw = json.load(f)
+    return {name: (r, g, b) for name, (r, g, b) in raw.items()}
+
+
+def resolve_color(name: str) -> Optional[tuple[int, int, int]]:
+    """Return ``(r, g, b)`` for *name*, or ``None`` if unknown."""
+    if not name:
+        return None
+    return _palette().get(_normalize(name))
+
+
+def palette_size() -> int:
+    """Number of known color names (useful in tests)."""
+    return len(_palette())

--- a/src/ha_workflow/inference.py
+++ b/src/ha_workflow/inference.py
@@ -1,0 +1,57 @@
+"""Infer the HA service (action) to call for a given domain + user-supplied params.
+
+Used by the quick-exec flow where the user types
+``<entity_id> <param_str>`` and expects the workflow to figure out the
+right service (e.g. ``light.turn_on`` when they supply brightness/color).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from ha_workflow.entities import ACTION_PARAMS, get_domain_config
+
+
+def infer_action(domain: str, param_keys: Iterable[str]) -> str:
+    """Pick the best-matching action in *domain* for the supplied *param_keys*.
+
+    Rules:
+
+    1. No params supplied → the domain's default action
+       (e.g. ``light`` → ``toggle``).
+    2. Else, score every parameterized action registered for *domain* by
+       the number of user-supplied keys it declares.  The strict winner is
+       returned.
+    3. On a tie (or when nothing matches), fall back to the default action.
+    4. Unknown domain with no default → ``""``.
+
+    The returned string is always safe to pass to ``dispatch_action`` — it's
+    either a valid action for the domain or an empty string that the
+    dispatcher will reject with a clear error.
+    """
+    keys = {k for k in param_keys if k}
+    default = get_domain_config(domain).default_action
+
+    if not keys:
+        return default
+
+    candidates = [
+        (action, set(p.name for p in params))
+        for (dom, action), params in ACTION_PARAMS.items()
+        if dom == domain
+    ]
+    if not candidates:
+        return default
+
+    scored = [(len(keys & declared), action) for action, declared in candidates]
+    scored.sort(key=lambda t: (-t[0], t[1]))  # highest score, then alpha for stability
+
+    top_score = scored[0][0]
+    if top_score == 0:
+        return default
+    # Strict winner only — avoid guessing on ties (e.g. cover.open_cover vs
+    # cover.close_cover both take ``position``).
+    if len(scored) > 1 and scored[1][0] == top_score:
+        return default
+
+    return scored[0][1]

--- a/src/ha_workflow/params.py
+++ b/src/ha_workflow/params.py
@@ -5,10 +5,47 @@ from __future__ import annotations
 import math
 from typing import Optional, Union
 
+from ha_workflow.colors import resolve_color
 from ha_workflow.entities import get_action_params
+
+# Short aliases users can type; the canonical HA service_data key on the right.
+_KEY_ALIASES: dict[str, str] = {
+    "color": "color_name",
+}
 
 # Type produced by the parser — values are coerced to their declared types.
 ParamValue = Union[int, float, str, bool]
+
+
+def extract_param_keys(raw: str) -> list[str]:
+    """Return the canonical key names the user supplied in *raw*.
+
+    Aliases are resolved (``color`` → ``color_name``) and the ``rgb_color``
+    triplet is detected specially.  Used by the quick-exec flow to pick the
+    right action before full parsing; safe to call on partially-typed input.
+    """
+    if not raw or not raw.strip():
+        return []
+    keys: list[str] = []
+    remaining = raw
+    if "rgb_color:" in remaining:
+        keys.append("rgb_color")
+        before, rgb_rest = remaining.split("rgb_color:", 1)
+        try:
+            _, after = _extract_rgb(rgb_rest)
+        except ValueError:
+            after = ""
+        parts = [p.strip() for p in [before.rstrip(",").strip(), after] if p.strip()]
+        remaining = ",".join(parts)
+    for pair in remaining.split(","):
+        pair = pair.strip()
+        if ":" not in pair:
+            continue
+        key, _ = pair.split(":", 1)
+        key = _KEY_ALIASES.get(key.strip(), key.strip())
+        if key:
+            keys.append(key)
+    return keys
 
 
 def parse_service_params(
@@ -27,6 +64,9 @@ def parse_service_params(
     * **brightness** — a trailing ``%`` converts the percentage (0-100) to the
       HA 0-255 range.
     * **rgb_color** — ``"255,0,0"`` is converted to ``[255, 0, 0]``.
+    * **color / color_name** — a known named color (``red``, ``eggshell``,
+      ``warm_white``, etc.) is resolved to ``rgb_color`` so HA gets coordinates
+      it always understands.  Unknown names pass through as ``color_name``.
 
     Raises :class:`ValueError` on parse or validation failures.
     """
@@ -60,6 +100,17 @@ def parse_service_params(
         value = value.strip()
         if not key:
             raise ValueError(f"Empty parameter name in: {pair!r}")
+
+        key = _KEY_ALIASES.get(key, key)
+
+        # Color-name resolution: turn known names into rgb_color so HA
+        # receives a palette-independent coordinate.
+        if key == "color_name":
+            rgb = resolve_color(value)
+            if rgb is not None:
+                result["rgb_color"] = [rgb[0], rgb[1], rgb[2]]
+                continue
+            # Unknown name — fall through and let HA try color_name.
 
         param_def = param_defs.get(key)
         if param_def is None:

--- a/src/ha_workflow/query_parser.py
+++ b/src/ha_workflow/query_parser.py
@@ -13,6 +13,10 @@ from ha_workflow.entities import DOMAIN_REGISTRY
 # ---------------------------------------------------------------------------
 
 _DOMAIN_PREFIX_RE = re.compile(r"^([a-z_]+):(.*)$")
+# Entity IDs are ``<domain>.<object_id>`` where both sides are lowercase
+# identifiers / digits / underscores.  We require a ``.`` and a known domain
+# so quick-exec only fires on well-formed entity references.
+_ENTITY_ID_RE = re.compile(r"^([a-z_]+)\.([a-z0-9_]+)$")
 
 
 @dataclass(frozen=True)
@@ -23,19 +27,28 @@ class ParsedQuery:
     ----------
     mode:
         ``"fuzzy"`` for standard fuzzy search, ``"regex"`` for regex matching,
-        or ``"domain_browse"`` when a domain filter is given with no text.
+        ``"domain_browse"`` when a domain filter is given with no text, or
+        ``"quick_exec"`` when the input is an entity_id optionally followed
+        by a parameter string (e.g. ``light.foo brightness:80,color:red``).
     text:
         The search text after extracting modifiers.
     domain_filter:
         Domain name to restrict results (e.g. ``"light"``), or ``None``.
     regex_pattern:
         Regex pattern string extracted from ``/pattern/`` syntax, or ``None``.
+    entity_id:
+        For ``quick_exec`` mode — the fully-qualified entity ID.
+    raw_params:
+        For ``quick_exec`` mode — the raw comma-separated param string
+        (may be empty, meaning "fire the default action with no params").
     """
 
-    mode: str  # "fuzzy" | "regex" | "domain_browse"
+    mode: str  # "fuzzy" | "regex" | "domain_browse" | "quick_exec"
     text: str
     domain_filter: Optional[str]
     regex_pattern: Optional[str]
+    entity_id: Optional[str] = None
+    raw_params: Optional[str] = None
 
 
 # ---------------------------------------------------------------------------
@@ -46,11 +59,17 @@ class ParsedQuery:
 def parse_query(raw: str) -> ParsedQuery:
     """Parse *raw* query text into a :class:`ParsedQuery`.
 
-    Supports three syntaxes:
+    Supports four syntaxes:
 
     1. ``/pattern/`` — regex search
-    2. ``domain:text`` — domain-filtered fuzzy search (or browse if *text* empty)
-    3. Plain text — standard fuzzy search
+    2. ``<domain>.<object_id> [params]`` — quick-exec (needs a known domain
+       and, at call time, an entity that actually exists in the cache)
+    3. ``domain:text`` — domain-filtered fuzzy search (or browse if *text* empty)
+    4. Plain text — standard fuzzy search
+
+    Quick-exec detection here only validates *shape* — whether the entity
+    exists in the cache is the caller's responsibility, so typos cleanly
+    fall back to fuzzy search.
     """
     stripped = raw.strip()
 
@@ -64,7 +83,20 @@ def parse_query(raw: str) -> ParsedQuery:
             regex_pattern=pattern,
         )
 
-    # 2. Domain filter syntax: domain:text
+    # 2. Quick-exec: <entity_id> [params]
+    first, _, rest = stripped.partition(" ")
+    em = _ENTITY_ID_RE.match(first)
+    if em and em.group(1) in DOMAIN_REGISTRY:
+        return ParsedQuery(
+            mode="quick_exec",
+            text="",
+            domain_filter=None,
+            regex_pattern=None,
+            entity_id=first,
+            raw_params=rest.strip(),
+        )
+
+    # 3. Domain filter syntax: domain:text
     m = _DOMAIN_PREFIX_RE.match(stripped)
     if m:
         candidate_domain = m.group(1)
@@ -85,7 +117,7 @@ def parse_query(raw: str) -> ParsedQuery:
             )
         # Invalid domain prefix — fall through to plain fuzzy search
 
-    # 3. Plain fuzzy search
+    # 4. Plain fuzzy search
     return ParsedQuery(
         mode="fuzzy",
         text=stripped,

--- a/src/ha_workflow/scripts/search_filter.py
+++ b/src/ha_workflow/scripts/search_filter.py
@@ -31,6 +31,8 @@ import ha_lib.suggestions as _lib_suggestions  # noqa: E402
 from ha_lib.config import Config  # noqa: E402
 from ha_lib.entities import Entity, get_domain_config  # noqa: E402
 from ha_lib.errors import handle_error  # noqa: E402
+from ha_lib.inference import infer_action  # noqa: E402
+from ha_lib.params import extract_param_keys, parse_service_params  # noqa: E402
 from ha_lib.query_parser import ParsedQuery, parse_query  # noqa: E402
 from ha_lib.usage import UsageRecord, open_usage_tracker  # noqa: E402
 from ha_workflow.alfred import (  # noqa: E402
@@ -283,6 +285,8 @@ def main() -> None:
 
             if parsed.mode == "regex":
                 output = _search_regex(cache, parsed)
+            elif parsed.mode == "quick_exec":
+                output = _quick_exec(cache, parsed, usage_stats, query)
             elif parsed.domain_filter:
                 output = _search_domain_filtered(cache, parsed, usage_stats, query)
             else:
@@ -332,6 +336,104 @@ def _search_domain_filtered(
         domain_entities, parsed.text, usage_stats=usage_stats
     )
     return _build_search_output(results, query)
+
+
+def _format_param_summary(parsed: dict[str, object]) -> str:
+    """Short human-readable summary of parsed service params."""
+    parts: list[str] = []
+    for k, v in parsed.items():
+        if k == "brightness" and isinstance(v, int):
+            pct = round(v / 255 * 100)
+            parts.append(f"brightness={v}/255 (\u2248{pct}%)")
+        elif k == "rgb_color" and isinstance(v, list) and len(v) == 3:
+            parts.append(f"rgb={v[0]},{v[1]},{v[2]}")
+        else:
+            parts.append(f"{k}={v}")
+    return ", ".join(parts)
+
+
+def _quick_exec(
+    cache: _lib_cache.EntityCache,
+    parsed: ParsedQuery,
+    usage_stats: dict[str, UsageRecord],
+    query: str,
+) -> AlfredOutput:
+    """Build an Alfred output for the quick-exec syntax.
+
+    If the entity is unknown, fall back to fuzzy search so typos behave like
+    normal queries.  If params fail to parse, show an error row **followed**
+    by fuzzy matches so the user can still find what they meant.
+    """
+    entity_id = parsed.entity_id or ""
+    raw_params = parsed.raw_params or ""
+
+    entity = cache.get_by_entity_id(entity_id)
+    if entity is None:
+        # Unknown entity — run normal fuzzy search over the whole query.
+        fallback = ParsedQuery(
+            mode="fuzzy",
+            text=query.strip(),
+            domain_filter=None,
+            regex_pattern=None,
+        )
+        return _search_fuzzy(cache, fallback, usage_stats, query)
+
+    dc = get_domain_config(entity.domain)
+
+    # Two-pass: extract the keys the user typed so infer_action can pick the
+    # right service, then re-parse with that action for type coercion +
+    # validation (e.g. brightness:80% → 204 when action is light.turn_on).
+    action = infer_action(entity.domain, extract_param_keys(raw_params))
+    try:
+        service_data = (
+            parse_service_params(raw_params, entity.domain, action)
+            if raw_params
+            else {}
+        )
+    except ValueError as exc:
+        items: list[AlfredItem] = [
+            AlfredItem(
+                title=f"Invalid parameters for {entity.friendly_name}",
+                subtitle=str(exc),
+                icon=AlfredIcon(path=dc.icon_path),
+                valid=False,
+            )
+        ]
+        return AlfredOutput(items=items)
+
+    if not action:
+        return AlfredOutput(
+            items=[
+                AlfredItem(
+                    title=f"No action available for {entity.friendly_name}",
+                    subtitle=f"Domain '{entity.domain}' has no default action",
+                    icon=AlfredIcon(path=dc.icon_path),
+                    valid=False,
+                )
+            ]
+        )
+
+    action_label = action.replace("_", " ").title()
+    if service_data:
+        summary = _format_param_summary(service_data)
+        subtitle = f"{action_label} \u2192 {summary}"
+    else:
+        subtitle = f"{action_label} \u00b7 {entity.entity_id}"
+
+    item = AlfredItem(
+        title=f"\u21b5 {action_label} {entity.friendly_name}",
+        subtitle=subtitle,
+        arg=entity.entity_id,
+        icon=AlfredIcon(path=dc.icon_path),
+        variables={
+            "entity_id": entity.entity_id,
+            "action": action,
+            "domain": entity.domain,
+            "params": raw_params,
+        },
+        valid=True,
+    )
+    return AlfredOutput(items=[item])
 
 
 def _search_fuzzy(

--- a/tests/test_colors.py
+++ b/tests/test_colors.py
@@ -1,0 +1,45 @@
+"""Tests for ha_workflow.colors."""
+
+from __future__ import annotations
+
+from ha_workflow.colors import palette_size, resolve_color
+
+
+class TestResolveColor:
+    def test_css4_red(self) -> None:
+        assert resolve_color("red") == (255, 0, 0)
+
+    def test_css4_white(self) -> None:
+        assert resolve_color("white") == (255, 255, 255)
+
+    def test_xkcd_eggshell(self) -> None:
+        # XKCD: eggshell -> #ffffd4
+        assert resolve_color("eggshell") == (255, 255, 212)
+
+    def test_ha_extra_warm_white(self) -> None:
+        rgb = resolve_color("warm_white")
+        assert rgb is not None and len(rgb) == 3
+
+    def test_case_insensitive(self) -> None:
+        assert resolve_color("RED") == resolve_color("red")
+        assert resolve_color("Eggshell") == resolve_color("eggshell")
+
+    def test_space_dash_underscore_equivalence(self) -> None:
+        a = resolve_color("warm white")
+        b = resolve_color("warm-white")
+        c = resolve_color("warm_white")
+        assert a is not None
+        assert a == b == c
+
+    def test_unknown_color(self) -> None:
+        assert resolve_color("not_a_real_color_xyz") is None
+
+    def test_empty_string(self) -> None:
+        assert resolve_color("") is None
+
+    def test_whitespace_stripped(self) -> None:
+        assert resolve_color("  red  ") == (255, 0, 0)
+
+    def test_palette_is_substantial(self) -> None:
+        # Should comfortably exceed 1000 once CSS4 + XKCD + HA extras are merged.
+        assert palette_size() > 900

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -1,0 +1,51 @@
+"""Tests for ha_workflow.inference."""
+
+from __future__ import annotations
+
+from ha_workflow.inference import infer_action
+
+
+class TestInferAction:
+    def test_no_params_returns_default(self) -> None:
+        # light's default action is ``toggle``.
+        assert infer_action("light", []) == "toggle"
+
+    def test_light_with_brightness_infers_turn_on(self) -> None:
+        assert infer_action("light", ["brightness"]) == "turn_on"
+
+    def test_light_with_color_and_transition_infers_turn_on(self) -> None:
+        assert (
+            infer_action("light", ["brightness", "color_name", "transition"])
+            == "turn_on"
+        )
+
+    def test_light_with_rgb_color_infers_turn_on(self) -> None:
+        assert infer_action("light", ["rgb_color"]) == "turn_on"
+
+    def test_climate_with_temperature_infers_set_temperature(self) -> None:
+        assert infer_action("climate", ["temperature"]) == "set_temperature"
+
+    def test_media_player_with_volume_infers_volume_set(self) -> None:
+        assert infer_action("media_player", ["volume_level"]) == "volume_set"
+
+    def test_fan_with_percentage_infers_turn_on(self) -> None:
+        assert infer_action("fan", ["percentage"]) == "turn_on"
+
+    def test_cover_position_tie_falls_back_to_default(self) -> None:
+        # Both open_cover and close_cover declare ``position`` — ambiguous, so
+        # we should not guess.  Fall back to the domain default (``toggle``).
+        assert infer_action("cover", ["position"]) == "toggle"
+
+    def test_unknown_key_falls_back_to_default(self) -> None:
+        # No action declares ``wat`` for lights; fall back to default.
+        assert infer_action("light", ["wat"]) == "toggle"
+
+    def test_unknown_domain_empty(self) -> None:
+        assert infer_action("nonesuch_domain", ["brightness"]) == ""
+
+    def test_input_number_single_action(self) -> None:
+        assert infer_action("input_number", ["value"]) == "set_value"
+
+    def test_empty_keys_filtered(self) -> None:
+        # Empty string keys should be ignored, not treated as "has params".
+        assert infer_action("light", ["", "  "]) == "toggle"

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from ha_workflow.params import parse_service_params
+from ha_workflow.params import extract_param_keys, parse_service_params
 
 
 class TestBasicParsing:
@@ -149,3 +149,63 @@ class TestInputHelpers:
     def test_input_text(self) -> None:
         result = parse_service_params("value:hello world", "input_text", "set_value")
         assert result == {"value": "hello world"}
+
+
+class TestColorResolution:
+    def test_color_alias_resolves_named_to_rgb(self) -> None:
+        # ``color`` is an alias for ``color_name`` and known palette entries
+        # become rgb_color so HA gets a coordinate rather than a palette name.
+        result = parse_service_params("color:red", "light", "turn_on")
+        assert result == {"rgb_color": [255, 0, 0]}
+
+    def test_color_name_resolves_to_rgb(self) -> None:
+        result = parse_service_params("color_name:eggshell", "light", "turn_on")
+        assert result == {"rgb_color": [255, 255, 212]}
+
+    def test_unknown_color_passes_through_as_name(self) -> None:
+        # Let HA handle truly unknown names — we don't swallow them.
+        result = parse_service_params("color:not_a_real_color_xyz", "light", "turn_on")
+        assert result == {"color_name": "not_a_real_color_xyz"}
+
+    def test_color_combined_with_brightness(self) -> None:
+        result = parse_service_params(
+            "brightness:80%,color:eggshell,transition:10",
+            "light",
+            "turn_on",
+        )
+        # 80% → ceil(0.8 * 255) = 204
+        assert result == {
+            "brightness": 204,
+            "rgb_color": [255, 255, 212],
+            "transition": 10.0,
+        }
+
+
+class TestExtractParamKeys:
+    def test_empty(self) -> None:
+        assert extract_param_keys("") == []
+        assert extract_param_keys("   ") == []
+
+    def test_single_key(self) -> None:
+        assert extract_param_keys("brightness:50") == ["brightness"]
+
+    def test_color_alias_resolved_to_color_name(self) -> None:
+        assert extract_param_keys("color:red") == ["color_name"]
+
+    def test_rgb_color_detected(self) -> None:
+        # rgb_color is detected specially so its comma-separated triplet
+        # isn't mis-parsed as three key:value pairs.
+        keys = extract_param_keys("rgb_color:255,0,0,transition:2")
+        assert "rgb_color" in keys
+        assert "transition" in keys
+
+    def test_multiple_keys(self) -> None:
+        keys = extract_param_keys("brightness:80%,color:eggshell,transition:10")
+        assert keys == ["brightness", "color_name", "transition"]
+
+    def test_skips_malformed(self) -> None:
+        # Pair without a colon is simply skipped — never raises.
+        assert extract_param_keys("brightness:50,oops,color:red") == [
+            "brightness",
+            "color_name",
+        ]

--- a/tests/test_query_parser.py
+++ b/tests/test_query_parser.py
@@ -126,3 +126,49 @@ class TestEdgeCases:
         # Space before colon — not a domain filter
         assert result.mode == "fuzzy"
         assert result.text == "light :bedroom"
+
+
+class TestQuickExec:
+    def test_entity_only(self) -> None:
+        result = parse_query("light.bedroom_lamp")
+        assert result.mode == "quick_exec"
+        assert result.entity_id == "light.bedroom_lamp"
+        assert result.raw_params == ""
+
+    def test_entity_with_params(self) -> None:
+        result = parse_query(
+            "light.aras_room_light_group_all brightness:80,color:eggshell,transition:10"
+        )
+        assert result.mode == "quick_exec"
+        assert result.entity_id == "light.aras_room_light_group_all"
+        assert result.raw_params == "brightness:80,color:eggshell,transition:10"
+
+    def test_entity_with_spaced_params(self) -> None:
+        # Everything after the first space is the param blob; internal spaces
+        # survive so ``brightness:80, color:red`` still parses downstream.
+        result = parse_query("switch.kitchen  brightness:50 ,color:red")
+        assert result.mode == "quick_exec"
+        assert result.entity_id == "switch.kitchen"
+        assert result.raw_params == "brightness:50 ,color:red"
+
+    def test_underscored_domain(self) -> None:
+        result = parse_query("input_boolean.night_mode")
+        assert result.mode == "quick_exec"
+        assert result.entity_id == "input_boolean.night_mode"
+
+    def test_unknown_domain_falls_through(self) -> None:
+        # ``foo`` is not in the domain registry; should behave as fuzzy search.
+        result = parse_query("foo.bar")
+        assert result.mode == "fuzzy"
+        assert result.text == "foo.bar"
+
+    def test_bad_shape_falls_through(self) -> None:
+        # Missing object_id after the dot.
+        result = parse_query("light.")
+        assert result.mode == "fuzzy"
+        assert result.text == "light."
+
+    def test_dotted_text_not_entity(self) -> None:
+        # Multiple dots aren't a valid entity_id shape.
+        result = parse_query("light.foo.bar")
+        assert result.mode == "fuzzy"


### PR DESCRIPTION
## Summary

- Detect `<entity_id> [params]` in the search filter and emit a single executable Alfred item that fires on plain Enter (no submenu, no param-entry dialog).
- Infer the action from the domain + supplied param keys (e.g. `light.foo brightness:80%,color:eggshell,transition:10` → `light.turn_on`).
- Resolve named colors client-side to `rgb_color` using a bundled 1,052-entry palette (CSS4 + X11 + XKCD + HA extras) so HA gets a coordinate rather than a palette name.
- No plist changes — the existing `search-filter → run-script-action` edge already reads `entity_id` / `action` / `params` env vars.
- Unknown entity_id → fall back to fuzzy search so typos still behave normally.

## Test plan

- [x] Unit tests pass (`pytest`) — 416 passed, 4 skipped
- [x] ruff check / ruff format clean
- [x] mypy --strict clean on both packages
- [x] Smoke-tested end-to-end with a seeded cache: `light.aras_room_light_group_all brightness:80%,color:eggshell,transition:10` yields an Alfred item with `action=turn_on`, `brightness=204`, `rgb_color=[255,255,212]`, `valid=true`.
- [ ] Manual smoke in Alfred on the user's machine once the workflow is rebuilt

Closes #36