### PR TITLE
feat: prioritize entities with an alfred-preferred label

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ This is a native macOS Alfred workflow — not a Home Assistant add-on. It runs 
 3. Open the workflow's configuration in Alfred and set:
    - `HA_URL` — your Home Assistant URL (e.g., `http://homeassistant.local:8123`)
    - `HA_TOKEN` — your long-lived access token
+   - `HA_PREFERRED_LABEL` *(optional)* — HA label slug that floats tagged entities to the top of search results. Defaults to `alfred_preferred`.
 4. Type `ha` in Alfred followed by your search query
 
 ## Usage
@@ -56,6 +57,10 @@ This is a native macOS Alfred workflow — not a Home Assistant add-on. It runs 
 - `ha <query>` — search entities. **Enter** runs the default action (toggle, turn on/off, etc.)
 - **Cmd + Enter** — open the action sub-menu for the selected entity
 - In the action sub-menu, select **Set Params...** to enter parameters like `brightness:100` or `color_temp_kelvin:3000`
+
+### Promoting entities to the top
+
+Create a label in Home Assistant (Settings → Areas & zones → Labels) named **Alfred Preferred** — HA stores it with the slug `alfred_preferred`. Tag any entity *or device* with it and those entities float above unlabeled ones in search results. Device-level labels propagate to every entity on that device. Your own usage history still takes priority over labeled entities. Override the slug with `HA_PREFERRED_LABEL` if you prefer a different label name.
 
 ## Development
 

--- a/packages/ha_lib/cache.py
+++ b/packages/ha_lib/cache.py
@@ -40,7 +40,8 @@ class EntityCache:
                 last_changed  TEXT NOT NULL,
                 last_updated  TEXT NOT NULL,
                 area_name     TEXT NOT NULL DEFAULT '',
-                device_id     TEXT NOT NULL DEFAULT ''
+                device_id     TEXT NOT NULL DEFAULT '',
+                labels_json   TEXT NOT NULL DEFAULT '[]'
             );
 
             CREATE INDEX IF NOT EXISTS idx_entities_domain
@@ -58,6 +59,7 @@ class EntityCache:
         for col, ddl in (
             ("area_name", "area_name TEXT NOT NULL DEFAULT ''"),
             ("device_id", "device_id TEXT NOT NULL DEFAULT ''"),
+            ("labels_json", "labels_json TEXT NOT NULL DEFAULT '[]'"),
         ):
             try:
                 self._conn.execute(f"SELECT {col} FROM entities LIMIT 1")
@@ -76,8 +78,9 @@ class EntityCache:
         cur.executemany(
             "INSERT INTO entities "
             "(entity_id, domain, state, friendly_name, "
-            "attributes_json, last_changed, last_updated, area_name, device_id) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            "attributes_json, last_changed, last_updated, area_name, device_id, "
+            "labels_json) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             [
                 (
                     e.entity_id,
@@ -89,6 +92,7 @@ class EntityCache:
                     e.last_updated,
                     e.area_name,
                     e.device_id,
+                    json.dumps(list(e.labels)),
                 )
                 for e in entities
             ],
@@ -103,7 +107,8 @@ class EntityCache:
         """Return every cached entity."""
         cur = self._conn.execute(
             "SELECT entity_id, domain, state, friendly_name, "
-            "attributes_json, last_changed, last_updated, area_name, device_id "
+            "attributes_json, last_changed, last_updated, area_name, device_id, "
+            "labels_json "
             "FROM entities"
         )
         return [self._row_to_entity(row) for row in cur.fetchall()]
@@ -112,7 +117,8 @@ class EntityCache:
         """Return the cached entity with *entity_id*, or ``None`` if missing."""
         cur = self._conn.execute(
             "SELECT entity_id, domain, state, friendly_name, "
-            "attributes_json, last_changed, last_updated, area_name, device_id "
+            "attributes_json, last_changed, last_updated, area_name, device_id, "
+            "labels_json "
             "FROM entities WHERE entity_id = ?",
             (entity_id,),
         )
@@ -123,7 +129,8 @@ class EntityCache:
         """Return all cached entities in the given *domain*."""
         cur = self._conn.execute(
             "SELECT entity_id, domain, state, friendly_name, "
-            "attributes_json, last_changed, last_updated, area_name, device_id "
+            "attributes_json, last_changed, last_updated, area_name, device_id, "
+            "labels_json "
             "FROM entities WHERE domain = ?",
             (domain,),
         )
@@ -141,7 +148,8 @@ class EntityCache:
         pattern = f"%{query}%"
         cur = self._conn.execute(
             "SELECT entity_id, domain, state, friendly_name, "
-            "attributes_json, last_changed, last_updated, area_name, device_id "
+            "attributes_json, last_changed, last_updated, area_name, device_id, "
+            "labels_json "
             "FROM entities "
             "WHERE entity_id LIKE ? OR friendly_name LIKE ?",
             (pattern, pattern),
@@ -175,6 +183,12 @@ class EntityCache:
 
     @staticmethod
     def _row_to_entity(row: tuple[Any, ...]) -> Entity:
+        raw_labels = row[9] if len(row) > 9 else "[]"
+        try:
+            labels_list = json.loads(raw_labels) if raw_labels else []
+        except (TypeError, ValueError):
+            labels_list = []
+        labels = tuple(str(label) for label in labels_list if label)
         return Entity(
             entity_id=row[0],
             domain=row[1],
@@ -185,6 +199,7 @@ class EntityCache:
             last_updated=row[6],
             area_name=row[7],
             device_id=row[8],
+            labels=labels,
         )
 
 

--- a/packages/ha_lib/config.py
+++ b/packages/ha_lib/config.py
@@ -10,6 +10,7 @@ from typing import Optional
 from ha_lib.errors import ConfigError
 
 _DEFAULT_CACHE_TTL = 60
+_DEFAULT_PREFERRED_LABEL = "alfred_preferred"
 
 
 @dataclass(frozen=True)
@@ -26,6 +27,7 @@ class Config:
     cache_ttl: int
     cache_dir: Path
     data_dir: Path
+    preferred_label: str = _DEFAULT_PREFERRED_LABEL
 
     @classmethod
     def from_env(cls, env: Optional[dict[str, str]] = None) -> Config:
@@ -73,10 +75,16 @@ class Config:
             env.get("alfred_workflow_data", "").strip() or str(dev_fallback / "data")
         )
 
+        preferred_label = (
+            env.get("HA_PREFERRED_LABEL", "").strip().lower()
+            or _DEFAULT_PREFERRED_LABEL
+        )
+
         return cls(
             ha_url=ha_url,
             ha_token=ha_token,
             cache_ttl=cache_ttl,
             cache_dir=cache_dir,
             data_dir=data_dir,
+            preferred_label=preferred_label,
         )

--- a/packages/ha_lib/entities.py
+++ b/packages/ha_lib/entities.py
@@ -30,6 +30,7 @@ class Entity:
     last_updated: str
     area_name: str = ""
     device_id: str = ""
+    labels: tuple[str, ...] = ()
 
     @classmethod
     def from_state_dict(
@@ -37,6 +38,7 @@ class Entity:
         data: dict[str, Any],
         area_name: str = "",
         device_id: str = "",
+        labels: tuple[str, ...] = (),
     ) -> Entity:
         """Convert an HA REST API state dict to an :class:`Entity`."""
         entity_id: str = data["entity_id"]
@@ -52,6 +54,7 @@ class Entity:
             last_updated=data.get("last_updated", ""),
             area_name=area_name,
             device_id=device_id,
+            labels=labels,
         )
 
     @property

--- a/packages/ha_lib/search.py
+++ b/packages/ha_lib/search.py
@@ -168,6 +168,16 @@ def regex_search(
     return results
 
 
+def _is_preferred(entity: Entity, preferred_label: Optional[str]) -> bool:
+    """Return ``True`` if *entity* carries the configured preferred label."""
+    if not preferred_label:
+        return False
+    target = preferred_label.strip().lower()
+    if not target:
+        return False
+    return any(label.strip().lower() == target for label in entity.labels)
+
+
 def fuzzy_search(
     entities: list[Entity],
     query: str,
@@ -175,6 +185,7 @@ def fuzzy_search(
     max_results: int = 50,
     usage_stats: Optional[dict[str, UsageRecord]] = None,
     now: Optional[float] = None,
+    preferred_label: Optional[str] = None,
 ) -> list[Entity]:
     """Score and rank *entities* against *query*.
 
@@ -185,31 +196,58 @@ def fuzzy_search(
     score to prefer recently and frequently used entities.  An empty
     *query* returns entities sorted by usage score (most-used first),
     falling back to alphabetical order for entities with no usage history.
+
+    When *preferred_label* is provided, results are grouped into three
+    tiers within which the existing ordering applies:
+
+    1. Entities with a usage record (ordered by combined score).
+    2. Entities tagged with *preferred_label* but not yet used.
+    3. Everything else.
     """
     query = query.strip()
     ts = now if now is not None else time.time()
 
+    def _has_usage(entity_id: str) -> bool:
+        if not usage_stats:
+            return False
+        rec = usage_stats.get(entity_id)
+        return rec is not None and rec.use_count > 0
+
     if not query:
-        if usage_stats:
-            # Sort by usage score descending, then alphabetically
-            return sorted(
-                entities,
-                key=lambda e: (
-                    -_usage_score(e.entity_id, usage_stats, ts),
-                    e.friendly_name.lower(),
-                ),
-            )[:max_results]
-        return entities[:max_results]
 
-    scored: list[tuple[float, int, Entity]] = []
+        def _empty_key(e: Entity) -> tuple[int, float, str]:
+            if _has_usage(e.entity_id):
+                group = 0
+            elif _is_preferred(e, preferred_label):
+                group = 1
+            else:
+                group = 2
+            usage_score = (
+                -_usage_score(e.entity_id, usage_stats, ts) if usage_stats else 0.0
+            )
+            return (group, usage_score, e.friendly_name.lower())
+
+        return sorted(entities, key=_empty_key)[:max_results]
+
+    scored: list[tuple[int, float, int, Entity]] = []
     for idx, entity in enumerate(entities):
-        s = _score_entity_multi(entity, query)
-        if s > 0:
-            if usage_stats:
-                s += _usage_score(entity.entity_id, usage_stats, ts)
-            scored.append((s, idx, entity))
+        fuzzy = _score_entity_multi(entity, query)
+        if fuzzy <= 0:
+            continue
+        combined = fuzzy
+        if usage_stats:
+            combined += _usage_score(entity.entity_id, usage_stats, ts)
 
-    # Sort by score descending, then original order for stability
-    scored.sort(key=lambda x: (-x[0], x[1]))
+        if _has_usage(entity.entity_id):
+            group = 0
+        elif _is_preferred(entity, preferred_label):
+            group = 1
+        else:
+            group = 2
 
-    return [entity for _, _, entity in scored[:max_results]]
+        scored.append((group, -combined, idx, entity))
+
+    # Tier first, then combined score descending, then original order for stability.
+    scored.sort(key=lambda x: (x[0], x[1], x[2]))
+
+    return [entity for _, _, _, entity in scored[:max_results]]

--- a/specs/project-tracking/phase-1.6-preferred-label.md
+++ b/specs/project-tracking/phase-1.6-preferred-label.md
@@ -1,0 +1,81 @@
+# Phase 1.6: Preferred-Label Prioritization
+
+**Goal:** Let users tag entities (or devices) in Home Assistant with a label so those entities float above unlabeled ones in Alfred search results, without disturbing usage-history-based ranking.
+**Status:** In progress
+**Branch:** `feat/38-preferred-label`
+**Issue:** [#38](https://github.com/AYapejian/ay-alfred-homeassistant/issues/38)
+**Depends on:** Phase 1.5
+
+---
+
+## Tasks
+
+### 1.6.1 — Labels on `Entity`
+- [x] **Done** — 2026-04-21
+- Add `labels: tuple[str, ...] = ()` to `Entity` in `src/ha_workflow/entities.py` and `packages/ha_lib/entities.py`
+- `Entity.from_state_dict` takes a `labels` kwarg
+- **Tests:** `tests/test_entities.py` — default-empty + passed-through cases
+
+### 1.6.2 — Cache schema migration
+- [x] **Done** — 2026-04-21
+- Add `labels_json TEXT NOT NULL DEFAULT '[]'` column in `src/ha_workflow/cache.py` and `packages/ha_lib/cache.py`
+- Runtime migration handles legacy DBs created before the column existed
+- **Tests:** `tests/test_cache.py::TestLabels` — round-trip + legacy migration
+
+### 1.6.3 — Registry lookup for labels
+- [x] **Done** — 2026-04-21
+- Extend `_RegistryInfo` in `src/ha_workflow/cli.py` with `labels`
+- `_build_registry_lookup` reads `labels` from entity-registry entries and unions in the owning device's labels (device tags propagate to child entities, mirroring area resolution)
+- Area labels do **not** propagate (scope kept targeted to v1)
+- Labels normalized to lowercase, deduped
+
+### 1.6.4 — `HA_PREFERRED_LABEL` config
+- [x] **Done** — 2026-04-21
+- Add `preferred_label: str` to `Config` in both packages
+- Sourced from env var `HA_PREFERRED_LABEL`, default `alfred_preferred`, lowercased and stripped
+- Empty-string override falls back to the default
+- **Tests:** 4 new tests in `tests/test_config.py`
+
+### 1.6.5 — Tier-based search ordering
+- [x] **Done** — 2026-04-21
+- `fuzzy_search(..., preferred_label=None)` in both packages
+- Three-tier sort key: (0) entities with a usage record → (1) labeled entities → (2) the rest
+- Within each tier the existing combined `fuzzy_score + usage_boost` ordering applies
+- Empty-query path uses the same tiers, falling back to alphabetical within each tier
+- **Tests:** `tests/test_search.py::TestPreferredLabel` — 7 cases covering tier ordering, case-insensitive match, usage-still-wins, inclusion gating
+
+### 1.6.6 — Wire through CLI + script entry points
+- [x] **Done** — 2026-04-21
+- `src/ha_workflow/cli.py`: pass `config.preferred_label` into `_search_fuzzy` / `_search_domain_filtered`
+- `src/ha_workflow/scripts/search_filter.py`: same for the `_lib_search.fuzzy_search` paths plus `_quick_exec` fallback
+
+### 1.6.7 — Expose `HA_PREFERRED_LABEL` in Alfred
+- [x] **Done** — 2026-04-21
+- New `textfield` workflow variable in `workflow/info.plist` with default `alfred_preferred`
+- Updated workflow description comment block with the new variable
+
+### 1.6.8 — Docs
+- [x] **Done** — 2026-04-21
+- README: documented the label + override under the "Promoting entities to the top" section
+
+### 1.6.9 — Merge & changelog
+- [ ] Pending — open PR with `Closes #38`, address review, squash-merge, then log in `changelog.md` and flip phase status to Done in `status.md`
+
+---
+
+## Key decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| **Tier-based sort, not additive weight** | Users asked for history-first, then labeled, then rest. Additive weights drift with tuning; explicit tiers make the contract obvious. |
+| **Device labels propagate, area labels do not** | Mirrors the existing area-resolution pattern. Device tags are targeted enough that "every entity on this device" is usually the user's intent; area-wide promotion would be too broad. |
+| **Default slug `alfred_preferred`** | HA normalizes "Alfred Preferred" → `alfred_preferred`. Matches HA's conventions so setup is copy/paste from the UI. |
+| **Single label only (v1)** | Multiple labels / weighted priorities can come later; start with one clear signal. |
+
+---
+
+## Follow-ups
+
+- Visual hint in the Alfred row when an entity is preferred (icon badge or subtitle prefix)
+- Multi-label support (comma-separated) with ordered priority
+- Area-label propagation behind a second env var (if requested)

--- a/specs/project-tracking/status.md
+++ b/specs/project-tracking/status.md
@@ -1,7 +1,7 @@
 # Project Status
 
 **Project:** ay-alfred-homeassistant
-**Last updated:** 2026-03-21
+**Last updated:** 2026-04-21
 
 ---
 
@@ -9,8 +9,8 @@
 
 | Item | Value |
 |------|-------|
-| **Current phase** | Phase 3 — Actions & Entity Interaction |
-| **Active branch** | — (next: `feat/phase-3-actions`) |
+| **Current phase** | Phase 1.6 — Preferred-label prioritization (in progress) / Phase 3 queued |
+| **Active branch** | `feat/38-preferred-label` |
 | **Last completed phase** | Phase 1.5 — Enhanced Search |
 | **Last commit on main** | `bae99ed` — Phase 1.5 merged |
 | **Blockers** | None |
@@ -30,6 +30,7 @@
 | 2026-03-20 | **CI/packaging early (Phase 0)** | Every phase produces a testable `.alfredworkflow` artifact. |
 | 2026-03-21 | **No `uid` on entity items** | Prevents Alfred's built-in learning from overriding our usage-based ranking. Our fuzzy search + usage boost has full control over ordering. |
 | 2026-03-21 | **System commands via search** | System actions (cache refresh, usage clear) surface as search results with `__system__` entity_id, distinct icon, and "System" subtitle. Dispatched through `_cmd_action` → `_cmd_system_action`. |
+| 2026-04-21 | **Preferred-label tiering (not weight)** | Search results are grouped into explicit tiers: usage history → labeled (`HA_PREFERRED_LABEL`, default `alfred_preferred`) → everything else. Device-level labels propagate to child entities; area labels do not. Keeps the "usage wins" contract explicit instead of tuning weights. |
 
 ---
 
@@ -41,6 +42,7 @@
 | 1 | Configuration & HA Client | **Done** | `feat/phase-1-config-ha-client` | `48462ac` on main |
 | 2 | Entity Cache & Search | **Done** | `feat/phase-2-cache-search` | `1a48cc8` on main |
 | 1.5 | Enhanced Search | **Done** | `feat/phase-1.5-enhanced-search` | `bae99ed` on main |
+| 1.6 | Preferred-label prioritization | **In progress** | `feat/38-preferred-label` | — |
 | 3 | Actions & Entity Interaction | **Next** | — | — |
 | 4 | Polish & Usability | Planned | — | — |
 | 5 | WebSocket Listener | Deferred | — | — |

--- a/src/ha_workflow/cache.py
+++ b/src/ha_workflow/cache.py
@@ -40,7 +40,8 @@ class EntityCache:
                 last_changed  TEXT NOT NULL,
                 last_updated  TEXT NOT NULL,
                 area_name     TEXT NOT NULL DEFAULT '',
-                device_id     TEXT NOT NULL DEFAULT ''
+                device_id     TEXT NOT NULL DEFAULT '',
+                labels_json   TEXT NOT NULL DEFAULT '[]'
             );
 
             CREATE INDEX IF NOT EXISTS idx_entities_domain
@@ -58,6 +59,7 @@ class EntityCache:
         for col, ddl in (
             ("area_name", "area_name TEXT NOT NULL DEFAULT ''"),
             ("device_id", "device_id TEXT NOT NULL DEFAULT ''"),
+            ("labels_json", "labels_json TEXT NOT NULL DEFAULT '[]'"),
         ):
             try:
                 self._conn.execute(f"SELECT {col} FROM entities LIMIT 1")
@@ -76,8 +78,9 @@ class EntityCache:
         cur.executemany(
             "INSERT INTO entities "
             "(entity_id, domain, state, friendly_name, "
-            "attributes_json, last_changed, last_updated, area_name, device_id) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            "attributes_json, last_changed, last_updated, area_name, device_id, "
+            "labels_json) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             [
                 (
                     e.entity_id,
@@ -89,6 +92,7 @@ class EntityCache:
                     e.last_updated,
                     e.area_name,
                     e.device_id,
+                    json.dumps(list(e.labels)),
                 )
                 for e in entities
             ],
@@ -103,7 +107,8 @@ class EntityCache:
         """Return every cached entity."""
         cur = self._conn.execute(
             "SELECT entity_id, domain, state, friendly_name, "
-            "attributes_json, last_changed, last_updated, area_name, device_id "
+            "attributes_json, last_changed, last_updated, area_name, device_id, "
+            "labels_json "
             "FROM entities"
         )
         return [self._row_to_entity(row) for row in cur.fetchall()]
@@ -112,7 +117,8 @@ class EntityCache:
         """Return the cached entity with *entity_id*, or ``None`` if missing."""
         cur = self._conn.execute(
             "SELECT entity_id, domain, state, friendly_name, "
-            "attributes_json, last_changed, last_updated, area_name, device_id "
+            "attributes_json, last_changed, last_updated, area_name, device_id, "
+            "labels_json "
             "FROM entities WHERE entity_id = ?",
             (entity_id,),
         )
@@ -123,7 +129,8 @@ class EntityCache:
         """Return all cached entities in the given *domain*."""
         cur = self._conn.execute(
             "SELECT entity_id, domain, state, friendly_name, "
-            "attributes_json, last_changed, last_updated, area_name, device_id "
+            "attributes_json, last_changed, last_updated, area_name, device_id, "
+            "labels_json "
             "FROM entities WHERE domain = ?",
             (domain,),
         )
@@ -141,7 +148,8 @@ class EntityCache:
         pattern = f"%{query}%"
         cur = self._conn.execute(
             "SELECT entity_id, domain, state, friendly_name, "
-            "attributes_json, last_changed, last_updated, area_name, device_id "
+            "attributes_json, last_changed, last_updated, area_name, device_id, "
+            "labels_json "
             "FROM entities "
             "WHERE entity_id LIKE ? OR friendly_name LIKE ?",
             (pattern, pattern),
@@ -175,6 +183,12 @@ class EntityCache:
 
     @staticmethod
     def _row_to_entity(row: tuple[Any, ...]) -> Entity:
+        raw_labels = row[9] if len(row) > 9 else "[]"
+        try:
+            labels_list = json.loads(raw_labels) if raw_labels else []
+        except (TypeError, ValueError):
+            labels_list = []
+        labels = tuple(str(label) for label in labels_list if label)
         return Entity(
             entity_id=row[0],
             domain=row[1],
@@ -185,6 +199,7 @@ class EntityCache:
             last_updated=row[6],
             area_name=row[7],
             device_id=row[8],
+            labels=labels,
         )
 
 

--- a/src/ha_workflow/cli.py
+++ b/src/ha_workflow/cli.py
@@ -159,13 +159,31 @@ class _RegistryInfo(NamedTuple):
 
     area_name: str
     device_id: str
+    labels: tuple[str, ...]
+
+
+def _normalize_labels(raw: Any) -> tuple[str, ...]:
+    """Coerce an HA registry ``labels`` value into a tuple of lowercase slugs."""
+    if not raw:
+        return ()
+    if isinstance(raw, str):
+        raw = [raw]
+    out: list[str] = []
+    for item in raw:
+        if not item:
+            continue
+        s = str(item).strip().lower()
+        if s:
+            out.append(s)
+    return tuple(out)
 
 
 def _build_registry_lookup(client: HAClient) -> dict[str, _RegistryInfo]:
     """Fetch entity, device, and area registries.
 
     Returns ``{entity_id: _RegistryInfo}`` with area resolved through the
-    device when the entity itself has no direct ``area_id``.
+    device when the entity itself has no direct ``area_id``, and labels
+    unioned with the device's labels so device-level tags propagate.
     """
     try:
         # area_id → area name
@@ -176,15 +194,21 @@ def _build_registry_lookup(client: HAClient) -> dict[str, _RegistryInfo]:
             if aid and name:
                 area_names[aid] = name
 
-        # device id → area_id
+        # device id → (area_id, labels)
         device_areas: dict[str, str] = {}
+        device_labels: dict[str, tuple[str, ...]] = {}
         for dev in client.get_device_registry():
             did = dev.get("id", "")
+            if not did:
+                continue
             aid = dev.get("area_id", "")
-            if did and aid:
+            if aid:
                 device_areas[did] = aid
+            dev_labels = _normalize_labels(dev.get("labels"))
+            if dev_labels:
+                device_labels[did] = dev_labels
 
-        # entity_id → (area_name, device_id)
+        # entity_id → _RegistryInfo
         lookup: dict[str, _RegistryInfo] = {}
         for entry in client.get_entity_registry():
             eid = entry.get("entity_id", "")
@@ -199,7 +223,21 @@ def _build_registry_lookup(client: HAClient) -> dict[str, _RegistryInfo]:
                 area_id = device_areas.get(device_id, "")
 
             area_name = area_names.get(area_id, "")
-            lookup[eid] = _RegistryInfo(area_name=area_name, device_id=device_id)
+
+            # Union entity labels with device labels (device tags propagate
+            # to all child entities; duplicates are removed, order preserved).
+            entity_labels = _normalize_labels(entry.get("labels"))
+            dev_labels = device_labels.get(device_id, ())
+            merged: list[str] = list(entity_labels)
+            for label in dev_labels:
+                if label not in merged:
+                    merged.append(label)
+
+            lookup[eid] = _RegistryInfo(
+                area_name=area_name,
+                device_id=device_id,
+                labels=tuple(merged),
+            )
 
         return lookup
     except Exception:
@@ -226,6 +264,7 @@ def _refresh_cache(config: Config, cache: EntityCache) -> None:
                 s,
                 area_name=info.area_name if info else "",
                 device_id=info.device_id if info else "",
+                labels=info.labels if info else (),
             )
         )
     cache.refresh(entities)
@@ -392,9 +431,13 @@ def _cmd_search(query: str) -> None:
                 if parsed.mode == "regex":
                     output = _search_regex(cache, parsed)
                 elif parsed.domain_filter:
-                    output = _search_domain_filtered(cache, parsed, usage_stats)
+                    output = _search_domain_filtered(
+                        cache, parsed, usage_stats, config.preferred_label
+                    )
                 else:
-                    output = _search_fuzzy(cache, parsed, usage_stats)
+                    output = _search_fuzzy(
+                        cache, parsed, usage_stats, config.preferred_label
+                    )
 
                 if needs_refresh:
                     output.rerun = 1.0
@@ -428,11 +471,17 @@ def _search_domain_filtered(
     cache: EntityCache,
     parsed: ParsedQuery,
     usage_stats: dict[str, UsageRecord],
+    preferred_label: str,
 ) -> AlfredOutput:
     """Handle domain-filtered search (e.g. ``light:bedroom``)."""
     domain_entities = cache.get_by_domain(parsed.domain_filter or "")
     _dbg(f"search: {len(domain_entities)} entities in domain {parsed.domain_filter}")
-    results = fuzzy_search(domain_entities, parsed.text, usage_stats=usage_stats)
+    results = fuzzy_search(
+        domain_entities,
+        parsed.text,
+        usage_stats=usage_stats,
+        preferred_label=preferred_label,
+    )
     _dbg(f"search: {len(results)} results for {parsed.text!r}")
     return _build_search_output(results)
 
@@ -441,11 +490,17 @@ def _search_fuzzy(
     cache: EntityCache,
     parsed: ParsedQuery,
     usage_stats: dict[str, UsageRecord],
+    preferred_label: str,
 ) -> AlfredOutput:
     """Handle standard fuzzy search with optional domain suggestions."""
     all_entities = cache.get_all()
     _dbg(f"search: {len(all_entities)} entities in cache")
-    results = fuzzy_search(all_entities, parsed.text, usage_stats=usage_stats)
+    results = fuzzy_search(
+        all_entities,
+        parsed.text,
+        usage_stats=usage_stats,
+        preferred_label=preferred_label,
+    )
     _dbg(f"search: {len(results)} results for {parsed.text!r}")
     output = _build_search_output(results)
 

--- a/src/ha_workflow/config.py
+++ b/src/ha_workflow/config.py
@@ -10,6 +10,7 @@ from typing import Optional
 from ha_workflow.errors import ConfigError
 
 _DEFAULT_CACHE_TTL = 60
+_DEFAULT_PREFERRED_LABEL = "alfred_preferred"
 
 
 @dataclass(frozen=True)
@@ -26,6 +27,7 @@ class Config:
     cache_ttl: int
     cache_dir: Path
     data_dir: Path
+    preferred_label: str = _DEFAULT_PREFERRED_LABEL
 
     @classmethod
     def from_env(cls, env: Optional[dict[str, str]] = None) -> Config:
@@ -73,10 +75,16 @@ class Config:
             env.get("alfred_workflow_data", "").strip() or str(dev_fallback / "data")
         )
 
+        preferred_label = (
+            env.get("HA_PREFERRED_LABEL", "").strip().lower()
+            or _DEFAULT_PREFERRED_LABEL
+        )
+
         return cls(
             ha_url=ha_url,
             ha_token=ha_token,
             cache_ttl=cache_ttl,
             cache_dir=cache_dir,
             data_dir=data_dir,
+            preferred_label=preferred_label,
         )

--- a/src/ha_workflow/entities.py
+++ b/src/ha_workflow/entities.py
@@ -30,6 +30,7 @@ class Entity:
     last_updated: str
     area_name: str = ""
     device_id: str = ""
+    labels: tuple[str, ...] = ()
 
     @classmethod
     def from_state_dict(
@@ -37,6 +38,7 @@ class Entity:
         data: dict[str, Any],
         area_name: str = "",
         device_id: str = "",
+        labels: tuple[str, ...] = (),
     ) -> Entity:
         """Convert an HA REST API state dict to an :class:`Entity`."""
         entity_id: str = data["entity_id"]
@@ -52,6 +54,7 @@ class Entity:
             last_updated=data.get("last_updated", ""),
             area_name=area_name,
             device_id=device_id,
+            labels=labels,
         )
 
     @property

--- a/src/ha_workflow/scripts/search_filter.py
+++ b/src/ha_workflow/scripts/search_filter.py
@@ -298,11 +298,17 @@ def main() -> None:
                 if parsed.mode == "regex":
                     output = _search_regex(cache, parsed)
                 elif parsed.mode == "quick_exec":
-                    output = _quick_exec(cache, parsed, usage_stats, query)
+                    output = _quick_exec(
+                        cache, parsed, usage_stats, query, config.preferred_label
+                    )
                 elif parsed.domain_filter:
-                    output = _search_domain_filtered(cache, parsed, usage_stats, query)
+                    output = _search_domain_filtered(
+                        cache, parsed, usage_stats, query, config.preferred_label
+                    )
                 else:
-                    output = _search_fuzzy(cache, parsed, usage_stats, query)
+                    output = _search_fuzzy(
+                        cache, parsed, usage_stats, query, config.preferred_label
+                    )
 
                 if needs_refresh:
                     output.rerun = 1.0
@@ -338,10 +344,14 @@ def _search_domain_filtered(
     parsed: ParsedQuery,
     usage_stats: dict[str, UsageRecord],
     query: str,
+    preferred_label: str,
 ) -> AlfredOutput:
     domain_entities = cache.get_by_domain(parsed.domain_filter or "")
     results = _lib_search.fuzzy_search(
-        domain_entities, parsed.text, usage_stats=usage_stats
+        domain_entities,
+        parsed.text,
+        usage_stats=usage_stats,
+        preferred_label=preferred_label,
     )
     return _build_search_output(results, query)
 
@@ -365,6 +375,7 @@ def _quick_exec(
     parsed: ParsedQuery,
     usage_stats: dict[str, UsageRecord],
     query: str,
+    preferred_label: str,
 ) -> AlfredOutput:
     """Build an Alfred output for the quick-exec syntax.
 
@@ -384,7 +395,7 @@ def _quick_exec(
             domain_filter=None,
             regex_pattern=None,
         )
-        return _search_fuzzy(cache, fallback, usage_stats, query)
+        return _search_fuzzy(cache, fallback, usage_stats, query, preferred_label)
 
     dc = get_domain_config(entity.domain)
 
@@ -449,10 +460,14 @@ def _search_fuzzy(
     parsed: ParsedQuery,
     usage_stats: dict[str, UsageRecord],
     query: str,
+    preferred_label: str,
 ) -> AlfredOutput:
     all_entities = cache.get_all()
     results = _lib_search.fuzzy_search(
-        all_entities, parsed.text, usage_stats=usage_stats
+        all_entities,
+        parsed.text,
+        usage_stats=usage_stats,
+        preferred_label=preferred_label,
     )
     output = _build_search_output(results, query)
 

--- a/src/ha_workflow/search.py
+++ b/src/ha_workflow/search.py
@@ -168,6 +168,16 @@ def regex_search(
     return results
 
 
+def _is_preferred(entity: Entity, preferred_label: Optional[str]) -> bool:
+    """Return ``True`` if *entity* carries the configured preferred label."""
+    if not preferred_label:
+        return False
+    target = preferred_label.strip().lower()
+    if not target:
+        return False
+    return any(label.strip().lower() == target for label in entity.labels)
+
+
 def fuzzy_search(
     entities: list[Entity],
     query: str,
@@ -175,6 +185,7 @@ def fuzzy_search(
     max_results: int = 50,
     usage_stats: Optional[dict[str, UsageRecord]] = None,
     now: Optional[float] = None,
+    preferred_label: Optional[str] = None,
 ) -> list[Entity]:
     """Score and rank *entities* against *query*.
 
@@ -185,31 +196,58 @@ def fuzzy_search(
     score to prefer recently and frequently used entities.  An empty
     *query* returns entities sorted by usage score (most-used first),
     falling back to alphabetical order for entities with no usage history.
+
+    When *preferred_label* is provided, results are grouped into three
+    tiers within which the existing ordering applies:
+
+    1. Entities with a usage record (ordered by combined score).
+    2. Entities tagged with *preferred_label* but not yet used.
+    3. Everything else.
     """
     query = query.strip()
     ts = now if now is not None else time.time()
 
+    def _has_usage(entity_id: str) -> bool:
+        if not usage_stats:
+            return False
+        rec = usage_stats.get(entity_id)
+        return rec is not None and rec.use_count > 0
+
     if not query:
-        if usage_stats:
-            # Sort by usage score descending, then alphabetically
-            return sorted(
-                entities,
-                key=lambda e: (
-                    -_usage_score(e.entity_id, usage_stats, ts),
-                    e.friendly_name.lower(),
-                ),
-            )[:max_results]
-        return entities[:max_results]
 
-    scored: list[tuple[float, int, Entity]] = []
+        def _empty_key(e: Entity) -> tuple[int, float, str]:
+            if _has_usage(e.entity_id):
+                group = 0
+            elif _is_preferred(e, preferred_label):
+                group = 1
+            else:
+                group = 2
+            usage_score = (
+                -_usage_score(e.entity_id, usage_stats, ts) if usage_stats else 0.0
+            )
+            return (group, usage_score, e.friendly_name.lower())
+
+        return sorted(entities, key=_empty_key)[:max_results]
+
+    scored: list[tuple[int, float, int, Entity]] = []
     for idx, entity in enumerate(entities):
-        s = _score_entity_multi(entity, query)
-        if s > 0:
-            if usage_stats:
-                s += _usage_score(entity.entity_id, usage_stats, ts)
-            scored.append((s, idx, entity))
+        fuzzy = _score_entity_multi(entity, query)
+        if fuzzy <= 0:
+            continue
+        combined = fuzzy
+        if usage_stats:
+            combined += _usage_score(entity.entity_id, usage_stats, ts)
 
-    # Sort by score descending, then original order for stability
-    scored.sort(key=lambda x: (-x[0], x[1]))
+        if _has_usage(entity.entity_id):
+            group = 0
+        elif _is_preferred(entity, preferred_label):
+            group = 1
+        else:
+            group = 2
 
-    return [entity for _, _, entity in scored[:max_results]]
+        scored.append((group, -combined, idx, entity))
+
+    # Tier first, then combined score descending, then original order for stability.
+    scored.sort(key=lambda x: (x[0], x[1], x[2]))
+
+    return [entity for _, _, _, entity in scored[:max_results]]

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -19,6 +19,7 @@ def _entity(
     entity_id: str = "light.living_room",
     state: str = "on",
     friendly_name: str = "Living Room Light",
+    labels: tuple[str, ...] = (),
     **extra_attrs: Any,
 ) -> Entity:
     domain = entity_id.split(".", 1)[0]
@@ -31,6 +32,7 @@ def _entity(
         attributes=attrs,
         last_changed="2026-03-20T10:00:00+00:00",
         last_updated="2026-03-20T10:00:00+00:00",
+        labels=labels,
     )
 
 
@@ -268,3 +270,90 @@ class TestOpenCache:
         db_file = tmp_path / "cache" / "entities.db"
         assert db_file.exists()
         cache.close()
+
+
+class TestLabels:
+    """Labels round-trip through the cache and legacy DBs migrate cleanly."""
+
+    def test_labels_default_empty(self) -> None:
+        cache = _mem_cache()
+        cache.refresh(SAMPLE_ENTITIES)
+        result = cache.get_all()
+        assert all(e.labels == () for e in result)
+        cache.close()
+
+    def test_labels_roundtrip(self) -> None:
+        cache = _mem_cache()
+        tagged = [
+            _entity(
+                "light.kitchen",
+                labels=("alfred_preferred", "favorite"),
+            ),
+        ]
+        cache.refresh(tagged)
+        result = cache.get_all()
+        assert result[0].labels == ("alfred_preferred", "favorite")
+        cache.close()
+
+    def test_labels_roundtrip_get_by_entity_id(self) -> None:
+        cache = _mem_cache()
+        cache.refresh([_entity("light.a", labels=("alfred_preferred",))])
+        e = cache.get_by_entity_id("light.a")
+        assert e is not None
+        assert e.labels == ("alfred_preferred",)
+        cache.close()
+
+    def test_labels_roundtrip_get_by_domain(self) -> None:
+        cache = _mem_cache()
+        cache.refresh([_entity("light.a", labels=("favorite",))])
+        results = cache.get_by_domain("light")
+        assert results[0].labels == ("favorite",)
+        cache.close()
+
+    def test_migration_from_legacy_schema(self, tmp_path: Path) -> None:
+        """A DB created without labels_json should auto-migrate on open."""
+        import sqlite3
+
+        db_path = tmp_path / "legacy.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.executescript(
+            """
+            CREATE TABLE entities (
+                entity_id     TEXT PRIMARY KEY,
+                domain        TEXT NOT NULL,
+                state         TEXT NOT NULL,
+                friendly_name TEXT NOT NULL,
+                attributes_json TEXT NOT NULL,
+                last_changed  TEXT NOT NULL,
+                last_updated  TEXT NOT NULL,
+                area_name     TEXT NOT NULL DEFAULT '',
+                device_id     TEXT NOT NULL DEFAULT ''
+            );
+            CREATE TABLE cache_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+            """
+        )
+        conn.execute(
+            "INSERT INTO entities VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                "light.old",
+                "light",
+                "on",
+                "Old Light",
+                "{}",
+                "",
+                "",
+                "",
+                "",
+            ),
+        )
+        conn.commit()
+        conn.close()
+
+        cache = EntityCache(db_path)
+        try:
+            result = cache.get_all()
+            assert len(result) == 1
+            assert result[0].entity_id == "light.old"
+            assert result[0].labels == ()
+        finally:
+            cache.close()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -76,3 +76,19 @@ class TestConfigFromEnv:
         home = Path.home()
         assert cfg.cache_dir == home / ".cache" / "ha-workflow" / "cache"
         assert cfg.data_dir == home / ".cache" / "ha-workflow" / "data"
+
+    def test_preferred_label_default(self) -> None:
+        cfg = Config.from_env(_base_env())
+        assert cfg.preferred_label == "alfred_preferred"
+
+    def test_preferred_label_override(self) -> None:
+        env = {**_base_env(), "HA_PREFERRED_LABEL": "my_favorites"}
+        assert Config.from_env(env).preferred_label == "my_favorites"
+
+    def test_preferred_label_lowercased(self) -> None:
+        env = {**_base_env(), "HA_PREFERRED_LABEL": "  MixedCaseLabel  "}
+        assert Config.from_env(env).preferred_label == "mixedcaselabel"
+
+    def test_preferred_label_empty_falls_back_to_default(self) -> None:
+        env = {**_base_env(), "HA_PREFERRED_LABEL": "   "}
+        assert Config.from_env(env).preferred_label == "alfred_preferred"

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -126,6 +126,16 @@ class TestFromStateDict:
         e = Entity.from_state_dict(data, device_id="abc123")
         assert e.device_id == "abc123"
 
+    def test_labels_default_empty(self) -> None:
+        e = Entity.from_state_dict(_state_dict())
+        assert e.labels == ()
+
+    def test_labels_passed_through(self) -> None:
+        e = Entity.from_state_dict(
+            _state_dict(), labels=("alfred_preferred", "favorite")
+        )
+        assert e.labels == ("alfred_preferred", "favorite")
+
 
 class TestDeviceClass:
     def test_present(self) -> None:

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -23,6 +23,7 @@ def _entity(
     state: str = "on",
     friendly_name: str = "Living Room Light",
     area_name: str = "",
+    labels: tuple[str, ...] = (),
     **extra_attrs: Any,
 ) -> Entity:
     domain = entity_id.split(".", 1)[0]
@@ -36,6 +37,7 @@ def _entity(
         last_changed="",
         last_updated="",
         area_name=area_name,
+        labels=labels,
     )
 
 
@@ -442,3 +444,147 @@ class TestUsageBoost:
         ids = [e.entity_id for e in results]
         # roborock doesn't match "kitchen" regardless of usage
         assert "vacuum.roborock" not in ids
+
+
+# ---------------------------------------------------------------------------
+# Preferred-label tiering
+# ---------------------------------------------------------------------------
+
+
+class TestPreferredLabel:
+    """Tests for the ``preferred_label`` tiering in fuzzy_search."""
+
+    def test_no_label_is_noop(self) -> None:
+        """Without preferred_label, ordering matches the legacy behavior."""
+        entities = [
+            _entity("light.a", friendly_name="Kitchen Light A"),
+            _entity("light.b", friendly_name="Kitchen Light B", labels=("foo",)),
+        ]
+        r_without = fuzzy_search(entities, "kitchen")
+        r_with = fuzzy_search(entities, "kitchen", preferred_label=None)
+        assert [e.entity_id for e in r_without] == [e.entity_id for e in r_with]
+
+    def test_labeled_entity_floats_above_unlabeled(self) -> None:
+        """Given equal fuzzy scores, the labeled entity ranks first."""
+        entities = [
+            _entity("light.a", friendly_name="Kitchen Light A"),
+            _entity(
+                "light.b",
+                friendly_name="Kitchen Light B",
+                labels=("alfred_preferred",),
+            ),
+        ]
+        results = fuzzy_search(
+            entities, "kitchen light", preferred_label="alfred_preferred"
+        )
+        assert results[0].entity_id == "light.b"
+
+    def test_label_match_is_case_insensitive(self) -> None:
+        """Matching is case-insensitive on both sides."""
+        entities = [
+            _entity("light.a", friendly_name="Kitchen Light A"),
+            _entity(
+                "light.b",
+                friendly_name="Kitchen Light B",
+                labels=("Alfred_Preferred",),
+            ),
+        ]
+        results = fuzzy_search(
+            entities, "kitchen light", preferred_label="ALFRED_PREFERRED"
+        )
+        assert results[0].entity_id == "light.b"
+
+    def test_usage_beats_preferred(self) -> None:
+        """An entity with usage history outranks a labeled entity without usage."""
+        from ha_workflow.usage import UsageRecord
+
+        now = 1000000.0
+        entities = [
+            _entity(
+                "light.labeled",
+                friendly_name="Labeled Light",
+                labels=("alfred_preferred",),
+            ),
+            _entity("light.used", friendly_name="Used Light"),
+        ]
+        stats = {"light.used": UsageRecord("light.used", 5, now)}
+        results = fuzzy_search(
+            entities,
+            "light",
+            usage_stats=stats,
+            now=now,
+            preferred_label="alfred_preferred",
+        )
+        ids = [e.entity_id for e in results]
+        assert ids.index("light.used") < ids.index("light.labeled")
+
+    def test_labeled_beats_stronger_fuzzy_match_in_rest_tier(self) -> None:
+        """Across tiers, a labeled entity ranks above one with a better fuzzy
+        score that is not labeled and has no usage.
+        """
+        entities = [
+            _entity("light.exact_kitchen", friendly_name="Kitchen Light"),
+            _entity(
+                "light.weird",
+                friendly_name="Lightning Kit Chen Extender",
+                labels=("alfred_preferred",),
+            ),
+        ]
+        results = fuzzy_search(
+            entities, "kitchen light", preferred_label="alfred_preferred"
+        )
+        # The labeled entity is in tier 1, the unlabeled is in tier 2,
+        # so the labeled one must come first even with a weaker fuzzy score.
+        assert results[0].entity_id == "light.weird"
+
+    def test_empty_query_tier_ordering(self) -> None:
+        """Empty query: usage -> preferred (alpha) -> rest (alpha)."""
+        from ha_workflow.usage import UsageRecord
+
+        now = 1000000.0
+        entities = [
+            _entity("light.rest_z", friendly_name="Z Rest"),
+            _entity("light.rest_a", friendly_name="A Rest"),
+            _entity(
+                "light.pref_z",
+                friendly_name="Z Preferred",
+                labels=("alfred_preferred",),
+            ),
+            _entity(
+                "light.pref_a",
+                friendly_name="A Preferred",
+                labels=("alfred_preferred",),
+            ),
+            _entity("light.used", friendly_name="M Used"),
+        ]
+        stats = {"light.used": UsageRecord("light.used", 3, now)}
+        results = fuzzy_search(
+            entities,
+            "",
+            usage_stats=stats,
+            now=now,
+            preferred_label="alfred_preferred",
+        )
+        ids = [e.entity_id for e in results]
+        assert ids == [
+            "light.used",
+            "light.pref_a",
+            "light.pref_z",
+            "light.rest_a",
+            "light.rest_z",
+        ]
+
+    def test_unmatched_entities_still_excluded(self) -> None:
+        """A labeled entity that does not match the query is still excluded."""
+        entities = [
+            _entity(
+                "light.unrelated",
+                friendly_name="Garage Door",
+                labels=("alfred_preferred",),
+            ),
+            _entity("light.kitchen", friendly_name="Kitchen Light"),
+        ]
+        results = fuzzy_search(entities, "kitchen", preferred_label="alfred_preferred")
+        ids = [e.entity_id for e in results]
+        assert "light.unrelated" not in ids
+        assert "light.kitchen" in ids

--- a/workflow/info.plist
+++ b/workflow/info.plist
@@ -406,6 +406,7 @@ Configuration:
 - HA_URL: Your Home Assistant URL (e.g., http://homeassistant.local:8123)
 - HA_TOKEN: A long-lived access token from HA
 - CACHE_TTL: Cache refresh interval in seconds (default: 60)
+- HA_PREFERRED_LABEL: HA label slug that floats tagged entities to the top (default: alfred_preferred)
 
 Keyboard shortcuts from search results:
 - Enter: Execute default action for entity
@@ -528,6 +529,27 @@ Keyboard shortcuts from search results:
 			<string>textfield</string>
 			<key>variable</key>
 			<string>CACHE_TTL</string>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>default</key>
+				<string>alfred_preferred</string>
+				<key>placeholder</key>
+				<string>alfred_preferred</string>
+				<key>required</key>
+				<false/>
+				<key>trim</key>
+				<true/>
+			</dict>
+			<key>description</key>
+			<string>HA label (slug) whose entities float above unlabeled ones (default: alfred_preferred). Tag entities or devices with this label in Home Assistant to promote them.</string>
+			<key>label</key>
+			<string>Preferred Label</string>
+			<key>type</key>
+			<string>textfield</string>
+			<key>variable</key>
+			<string>HA_PREFERRED_LABEL</string>
 		</dict>
 	</array>
 	<key>variables</key>


### PR DESCRIPTION
## Summary
- Adds a new tier in search ranking so HA entities tagged with a label (default slug `alfred_preferred`) float above unlabeled ones, while usage history stays the top signal.
- Three-tier sort in `fuzzy_search`: usage history → labeled → rest. Applies to both empty-query listings and typed queries.
- Device labels propagate to their child entities (same pattern as area resolution). Area labels do **not** propagate.
- New `HA_PREFERRED_LABEL` Alfred workflow variable (default `alfred_preferred`), documented in README + `info.plist`.
- Cache schema migration adds `labels_json` with a forward migration for existing DBs.

## Test plan
- [x] `uv run pytest` — 436 passed, 4 skipped (integration)
- [x] `uv run ruff check src/ha_workflow packages/ha_lib tests` — clean
- [x] `uv run ruff format --check src/ha_workflow packages/ha_lib tests` — clean
- [x] `uv run mypy src/ha_workflow packages/ha_lib` — clean
- [ ] Manual: tag an entity with `Alfred Preferred` in HA, run `ha <query>`, confirm it ranks above unlabeled matches but below the user's usage history
- [ ] Manual: unset `HA_PREFERRED_LABEL`, confirm the default `alfred_preferred` slug still works
- [ ] Manual: upgrade an existing install to confirm the cache migration runs cleanly

Closes #38